### PR TITLE
Doc updates to encourage wallet devs to handle URI scheme

### DIFF
--- a/core/example/payment-flow-merchant/main.ts
+++ b/core/example/payment-flow-merchant/main.ts
@@ -34,7 +34,7 @@ async function main() {
     /**
      * Create a payment request link
      *
-     * Solana Pay uses a standard URI scheme across wallets for native SOL and SPL Token payments.
+     * Solana Pay uses a standard URL scheme across wallets for native SOL and SPL Token payments.
      * Several parameters are encoded within the link representing an intent to collect payment from a customer.
      */
     console.log('3. 💰 Create a payment request link \n');

--- a/core/example/payment-flow-merchant/simulateWalletInteraction.ts
+++ b/core/example/payment-flow-merchant/simulateWalletInteraction.ts
@@ -7,7 +7,7 @@ export async function simulateWalletInteraction(connection: Connection, url: str
     /**
      * For example only
      *
-     * The URL that triggers the wallet interaction; follows the Solana Pay URI scheme
+     * The URL that triggers the wallet interaction; follows the Solana Pay URL scheme
      * The parameters needed to create the correct transaction is encoded within the URL
      */
     const { recipient, message, memo, amount, reference, label } = parseURL(url);

--- a/docs/src/SPEC.md
+++ b/docs/src/SPEC.md
@@ -15,6 +15,8 @@ This standard draws inspiration from [BIP 21](https://github.com/bitcoin/bips/bl
 ## Motivation
 A standard URL protocol for requesting native SOL and SPL Token transfers allows for a better user experience across wallets and apps in the Solana ecosystem.
 
+Mobile wallets should ideally register to handle the URL scheme and provide a seamless yet secure experience when Solana Pay URLs are encountered in the environment.
+
 Applications should ensure that a payment transaction has been confirmed and contains a transfer of the expected amount and type before they release the goods or services being sold.
 
 By standardizing a simple approach to solving those problems, we ensure compatibility of applications and wallets.

--- a/docs/src/core/WALLET_INTEGRATION.md
+++ b/docs/src/core/WALLET_INTEGRATION.md
@@ -143,7 +143,7 @@ See [full code snippet][11]
 
 ## Deep linking
 
-Wallet providers building for mobile or wearable devices are encouraged to register their app as a handler for the Solana Pay URI scheme.
+Wallet providers building for mobile or wearable devices are encouraged to register their app as a handler for the Solana Pay URL scheme `solana:`.
 
 For example, when a payment request is presented as a QR code, the payer should ideally be able to read the code using the native scanning capability of their device and have the appropriate wallet open with the transaction prefilled.
 

--- a/docs/src/core/WALLET_INTEGRATION.md
+++ b/docs/src/core/WALLET_INTEGRATION.md
@@ -141,6 +141,14 @@ See [full code snippet][11]
 
 </details>
 
+## Deep linking
+
+Wallet providers building for mobile or wearable devices are encouraged to register their app as a handler for the Solana Pay URI scheme.
+
+For example, when a payment request is presented as a QR code, the payer should ideally be able to read the code using the native scanning capability of their device and have the appropriate wallet open with the transaction prefilled.
+
+URLs can be embedded in the environment in web pages, QR codes, NFC tags and potential new formats. To avoid inadvertent transfer of tokens, care must be taken when designing wallets to ensure that transactions cannot accidentally be triggered and sent.
+
 <!-- References -->
 
 [9]: https://github.com/solana-labs/solana-pay/blob/master/core/example/payment-flow-merchant/simulateWalletInteraction.ts#L13


### PR DESCRIPTION
Additions have been made to two Solana Pay document pages. These additions are intended to highlight, remind and encourage mobile wallet developers to register to handle the Solana Pay URI scheme. This is in support of the vision of seamless real-world payments using QR codes and NFC tags.

Feel free to edit it without my consultation/approval.

Relates to issue https://github.com/solana-labs/solana-pay/issues/57
Relates to contributor @jordansexton 