### PR TITLE
update README for shell command to open local instance

### DIFF
--- a/point-of-sale/README.md
+++ b/point-of-sale/README.md
@@ -63,7 +63,7 @@ yarn start
 
 ### Open the point of sale app
 ```shell
-open http://localhost:1234?recipient=Your+Merchant+Address&label=Your+Store+Name
+open "http://localhost:1234?recipient=Your+Merchant+Address&label=Your+Store+Name"
 ```
 
 ## Deploying to Vercel


### PR DESCRIPTION
Added quotes around URL in shell command to Open the point of sale app. My terminal was giving me an error when running the command without quotes around the URL.

Example: https://twitter.com/JoshCStein/status/1491208396632358914?s=20&t=hXBnltLw0BmpV3k76YmgVQ 

hat tip to @jordansexton for the assistance, again!