### PR TITLE
Fixed merchant example code

### DIFF
--- a/core/example/payment-flow-merchant/main.ts
+++ b/core/example/payment-flow-merchant/main.ts
@@ -105,13 +105,11 @@ async function main() {
     console.log('\n6. 🔗 Validate transaction \n');
 
     try {
-        const amountInLamports = amount.times(LAMPORTS_PER_SOL).integerValue(BigNumber.ROUND_FLOOR);
-
         await validateTransactionSignature(
             connection,
             signature,
             MERCHANT_WALLET,
-            amountInLamports,
+            amount,
             undefined,
             reference
         );


### PR DESCRIPTION
Fixed the following error:
```
❌ Payment failed ValidateTransactionSignatureError: amount not transferred
    at validateTransactionSignature
```
The validateTransactionSignature function takes in SOL, not LAMPORTS. 

