### PR TITLE
Support wallet disambiguation and deeplinking in protocol spec, url encoding, and url parsing

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -18,11 +18,15 @@ By standardizing a simple approach to solving those problems, we ensure compatib
 
 ## Specification
 ```
-solana:<recipient>?amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>
+https://some-solana-wallet.com/?recipient=<recipient>&amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>&request=<request>
+```
+or
+```
+solana:<recipient>?amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>&request=<request>
 ```
 
 ### Recipient
-A single `recipient` field is required as the pathname. The value must be the base58-encoded public key of a native SOL account. Associated token accounts must not be used.
+A single `recipient` field is required as a query param, or in cases where the `solana:` protocol is used, as a pathname. The value must be the base58-encoded public key of a native SOL account. Associated token accounts must not be used.
 
 Instead, to request an SPL token transfer, the `spl-token` field must be used to specify an SPL Token mint, from which the associated token address of the recipient address must be derived.
 
@@ -62,20 +66,30 @@ A single `memo` field is allowed as an optional query parameter. The value must 
 
 Wallets should display the memo to the user. The SPL Memo instruction must be included immediately before the SOL or SPL Token transfer instruction to avoid ambiguity with other instructions in the transaction.
 
+### Request
+A single `request` field is allowed as an optional query parameter. The value must be a URL-encoded string that describes the URL of the merchant's authentication server for the transaction.
+
+How wallets and merchants should handle authentication with `request` will be outlined in [Wallet Integration](./docs/src/core/WALLET_INTEGRATION.md) and [Merchant Integration](./docs/src/core/MERCHANT_INTEGRATION.md) respectively.
+
 ## Examples
 URL describing a transfer for 1 SOL:
+```
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId1234
+```
+
+URL describing a transfer for 1 SOL with no wallet disambiguation:
 ```
 solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId1234
 ```
 
 URL describing a transfer for 0.01 USDC
 ```
-solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678
 ```
 
 URL describing a generic SOL transfer. The user must be prompted for the exact amount.
 ```
-solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN&label=Michael&memo=4321ABCD
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=Michael&memo=4321ABCD
 ```
 
 ## Extensions

--- a/core/example/payment-flow-merchant/main.ts
+++ b/core/example/payment-flow-merchant/main.ts
@@ -105,14 +105,7 @@ async function main() {
     console.log('\n6. 🔗 Validate transaction \n');
 
     try {
-        await validateTransactionSignature(
-            connection,
-            signature,
-            MERCHANT_WALLET,
-            amount,
-            undefined,
-            reference
-        );
+        await validateTransactionSignature(connection, signature, MERCHANT_WALLET, amount, undefined, reference);
 
         // Update payment status
         paymentStatus = 'validated';

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/solana-pay",
     "license": "Apache-2.0",

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -2,7 +2,10 @@ import { PublicKey } from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
 
 /** @internal */
-export const URL_PROTOCOL = 'solana:';
+export const DEFAULT_URL_PROTOCOL = 'solana:';
+
+/** @internal */
+export const ACCEPTED_URL_PROTOCOLS = [DEFAULT_URL_PROTOCOL, 'https:', 'http:'];
 
 /** @internal */
 export const MEMO_PROGRAM_ID = new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');

--- a/core/src/encodeURL.ts
+++ b/core/src/encodeURL.ts
@@ -50,7 +50,7 @@ export interface EncodeURLComponents extends EncodeURLParams {
  * @param components.request
  */
 export function encodeURL({ recipient, wallet, ...params }: EncodeURLComponents): string {
-    let url = wallet ? wallet.toString() : DEFAULT_URL_PROTOCOL + encodeURIComponent(recipient.toBase58());
+    let url = wallet ?? DEFAULT_URL_PROTOCOL + encodeURIComponent(recipient.toBase58());
 
     // add the recipient as a url param if there is a wallet URL
     const encodedParams = encodeURLParams({ ...params, recipient: wallet ? recipient : undefined });

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -4,4 +4,5 @@ export * from './createTransaction';
 export * from './encodeURL';
 export * from './findTransactionSignature';
 export * from './parseURL';
+export * from './supportedWallets';
 export * from './validateTransactionSignature';

--- a/core/src/supportedWallets.ts
+++ b/core/src/supportedWallets.ts
@@ -1,0 +1,8 @@
+/**
+ * Enum of wallets with their registed url as the value.
+ * Each mobile wallet app should register their own wallet and url.
+ * Ex. `Phantom = "https://phantom.app/code?",`
+ */
+enum SupportedWallet {}
+
+export default SupportedWallet;

--- a/core/test/encodeURL.test.ts
+++ b/core/test/encodeURL.test.ts
@@ -30,6 +30,15 @@ describe('encodeURL', () => {
         expect(url).toBe(`solana:${recipient}`);
     });
 
+    it('encodes a url with recipient and request', () => {
+        const recipient = Keypair.generate().publicKey;
+        const request = 'https://solana.com/transact/';
+
+        const url = encodeURL({ request, recipient });
+
+        expect(url).toBe(`solana:${recipient}?request=${encodeURIComponent(request)}`);
+    });
+
     it('encodes a url with recipient and amount', () => {
         const recipient = Keypair.generate().publicKey;
         const amount = new BigNumber('1');

--- a/core/test/parseURL.test.ts
+++ b/core/test/parseURL.test.ts
@@ -9,7 +9,7 @@ describe('parseURL', () => {
                 const url =
                     'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.000000001&reference=82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678';
 
-                const { recipient, amount, splToken, reference, label, message, memo } = parseURL(url);
+                const { recipient, amount, splToken, reference, label, message, memo, request } = parseURL(url);
 
                 expect(recipient.equals(new PublicKey('mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'))).toBe(true);
                 expect(amount!.eq(new BigNumber('0.000000001'))).toBe(true);
@@ -19,13 +19,14 @@ describe('parseURL', () => {
                 expect(label).toBe('Michael');
                 expect(message).toBe('Thanks for all the fish');
                 expect(memo).toBe('OrderId5678');
+                expect(request).toBeUndefined();
             });
 
             it('should parse with spl-token', () => {
                 const url =
                     'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1.01&spl-token=82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678';
 
-                const { recipient, amount, splToken, reference, label, message, memo } = parseURL(url);
+                const { recipient, amount, splToken, reference, label, message, memo, request } = parseURL(url);
 
                 expect(recipient.equals(new PublicKey('mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'))).toBe(true);
                 expect(amount!.eq(new BigNumber('1.01'))).toBe(true);
@@ -34,13 +35,46 @@ describe('parseURL', () => {
                 expect(label).toBe('Michael');
                 expect(message).toBe('Thanks for all the fish');
                 expect(memo).toBe('OrderId5678');
+                expect(request).toBeUndefined();
+            });
+
+            it('should parse with request', () => {
+                const url =
+                    'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1.01&request=https%3A%2F%2Fsolana.com%2F&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678';
+
+                const { recipient, amount, splToken, reference, label, message, memo, request } = parseURL(url);
+
+                expect(recipient.equals(new PublicKey('mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'))).toBe(true);
+                expect(amount!.eq(new BigNumber('1.01'))).toBe(true);
+                expect(reference).toBeUndefined();
+                expect(label).toBe('Michael');
+                expect(message).toBe('Thanks for all the fish');
+                expect(memo).toBe('OrderId5678');
+                expect(request).toBe('https://solana.com/');
+            });
+
+            it('should parse with different protocol', () => {
+                const url =
+                    'https://solanawallet.app/code?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN&amount=0.000000001&reference=82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678';
+
+                const { recipient, amount, splToken, reference, label, message, memo, request } = parseURL(url);
+
+                expect(recipient.equals(new PublicKey('mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'))).toBe(true);
+                expect(amount!.eq(new BigNumber('0.000000001'))).toBe(true);
+                expect(splToken).toBeUndefined();
+                expect(reference).toHaveLength(1);
+                expect(reference![0]!.equals(new PublicKey('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'))).toBe(true);
+                expect(label).toBe('Michael');
+                expect(message).toBe('Thanks for all the fish');
+                expect(memo).toBe('OrderId5678');
+                expect(request).toBeUndefined();
             });
 
             it('should parse without an amount', () => {
                 const url =
                     'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?reference=82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678';
 
-                const { recipient, amount, splToken, reference, label, message, memo } = parseURL(url);
+                const { recipient, amount, splToken, reference, label, message, memo, request } = parseURL(url);
 
                 expect(recipient.equals(new PublicKey('mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'))).toBe(true);
                 expect(amount).toBeUndefined();
@@ -50,6 +84,7 @@ describe('parseURL', () => {
                 expect(label).toBe('Michael');
                 expect(message).toBe('Thanks for all the fish');
                 expect(memo).toBe('OrderId5678');
+                expect(request).toBeUndefined();
             });
         });
     });
@@ -86,6 +121,12 @@ describe('parseURL', () => {
             const url = 'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&reference=0xffff';
 
             expect(() => parseURL(url)).toThrow('reference invalid');
+        });
+
+        it('throws an error on invalid request', () => {
+            const url = 'solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&request=solana.com';
+
+            expect(() => parseURL(url)).toThrow('request invalid');
         });
     });
 });

--- a/docs/src/SPEC.md
+++ b/docs/src/SPEC.md
@@ -24,14 +24,17 @@ Mobile wallets should ideally register to handle the URL scheme and provide a se
 By standardizing a simple approach to solving those problems, we ensure compatibility of applications and wallets.
 
 ## Specification
-
 ```
-solana:<recipient>?amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>
+https://some-solana-wallet.com/?recipient=<recipient>&amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>&request=<request>
+```
+or
+```
+solana:<recipient>?amount=<amount>&label=<label>&message=<message>&memo=<memo>&reference=<reference>&request=<request>
 ```
 
 ### Recipient
 
-A single `recipient` field is required as the pathname. The value must be the base58-encoded public key of a native SOL account. Associated token accounts must not be used.
+A single `recipient` field is required as a query param, or in cases where the `solana:` protocol is used, as a pathname. The value must be the base58-encoded public key of a native SOL account. Associated token accounts must not be used.
 
 Instead, to request an SPL token transfer, the `spl-token` field must be used to specify an SPL Token mint, from which the associated token address of the recipient address must be derived.
 
@@ -77,9 +80,21 @@ A single `memo` field is allowed as an optional query parameter. The value must 
 
 Wallets should display the memo to the user. The SPL Memo instruction must be included immediately before the SOL or SPL Token transfer instruction to avoid ambiguity with other instructions in the transaction.
 
+### Request
+
+A single `request` field is allowed as an optional query parameter. The value must be a URL-encoded string that describes the URL of the merchant's authentication server for the transaction.
+
+How wallets and merchants should handle authentication with `request` will be outlined in [Wallet Integration](./core/WALLET_INTEGRATION.md) and [Merchant Integration](./core/MERCHANT_INTEGRATION.md) respectively.
+
 ## Examples
 
 URL describing a transfer for 1 SOL:
+
+```
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId1234
+```
+
+URL describing a transfer for 1 SOL with no wallet disambiguation:
 
 ```
 solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId1234
@@ -88,13 +103,13 @@ solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael&messag
 URL describing a transfer for 0.01 USDC
 
 ```
-solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&label=Michael&message=Thanks%20for%20all%20the%20fish&memo=OrderId5678
 ```
 
 URL describing a generic SOL transfer. The user must be prompted for the exact amount.
 
 ```
-solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=Michael&memo=4321ABCD
+https://some-solana-wallet.com/?recipient=mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=Michael&memo=4321ABCD
 ```
 
 ## Extensions


### PR DESCRIPTION
# Problem Overview

This branch addresses requests in https://github.com/solana-labs/solana-pay/issues/100 to update the Solana Pay protocol specification to support wallet disambiguation in iOS clients and deeplinking to address some security vulnerabilities.

# Solution & Decision Log
The open issue proposes several changes; this PR is the first step towards implementing those changes from Solana Pay's end. In addition to this, there will need to be followup PRs to fully close the issue.

## Handling the Spec Changes
The issue poster suggested to allow for a url like `https://phantom.app/code?` instead of the current url scheme `solana:`. However, the suggested URL has a path, which should be used for the `recipient` according to the current protocol spec. There are a few options of how we might want to handle this:
1. We can make a breaking change to the protocol spec and require `recipient` as a query parameter. I'm avoiding this since breaking changes are costly.
2. We can continue to keep the `recipient` in the path, and just parse it out of the end of the wallet URL (in the cases where we use a wallet URL). This is a bit of a rigid solution since it relies on wallet applications registering a wildcard route to handle `recipient` in the path. The parsing also feels a little hacky to me, so I’m not a fan of this one.
3. We can allow for a `recipient` query parameter. This will be encoded in the URL when a wallet is provided, otherwise it will default to putting `recipient` in the path. This solution is backwards compatible and flexible so I decided to implement this.

## Supporting Wallet Disambiguation
This solution creates a TypeScript enum for tracking supported wallets called `SupportedWallet`. Wallets can create PRs to add their wallet and their registered url to this enum. This branch leaves the enum empty for now, which means we can't build much around this until enum entries are added.

# Testing
- Documentation changes were manually verified in local docusaurus
- Code changes were tested via unit tests
  - Note: `encodeURL.test.ts` will need additional tests once supported wallets have been added to the `SupportedWallet` enum.

# Next Steps
1. System diagrams in documentation need to be updated to reflect complete call paths (given the new `request` query param usage). _This could be included in this PR but I don't have access to the files for these diagrams._
2. Documentation needs to be added on how to set up authentication servers for merchants and how to interact with authentication servers as wallets. _This could also be included in this PR, but would be confusing without the updated system diagrams._
3. The [Point of Sale](https://github.com/solana-labs/solana-pay/tree/master/point-of-sale) package needs to be updated to provide UIs for wallet selection.