### PR TITLE
Allow ATA owner to be off the curve

### DIFF
--- a/core/src/createTransaction.ts
+++ b/core/src/createTransaction.ts
@@ -99,13 +99,13 @@ export async function createTransaction(
         amount = amount.times(TEN.pow(mint.decimals)).integerValue(BigNumber.ROUND_FLOOR);
 
         // Get the payer's ATA and check that the account exists and can send tokens
-        const payerATA = await getAssociatedTokenAddress(splToken, payer);
+        const payerATA = await getAssociatedTokenAddress(splToken, payer, true);
         const payerAccount = await getAccount(connection, payerATA);
         if (!payerAccount.isInitialized) throw new CreateTransactionError('payer not initialized');
         if (payerAccount.isFrozen) throw new CreateTransactionError('payer frozen');
 
         // Get the recipient's ATA and check that the account exists and can receive tokens
-        const recipientATA = await getAssociatedTokenAddress(splToken, recipient);
+        const recipientATA = await getAssociatedTokenAddress(splToken, recipient, true);
         const recipientAccount = await getAccount(connection, recipientATA);
         if (!recipientAccount.isInitialized) throw new CreateTransactionError('recipient not initialized');
         if (recipientAccount.isFrozen) throw new CreateTransactionError('recipient frozen');


### PR DESCRIPTION
I have been working on an integration that allows a program to accept payment using Solana Pay.

When getting the payer and recipient ATA, Solana Pay SDK uses the default value for `allowOwnerOffCurve` which happens to be `false`. This makes it a bit harder if one wanted to integrate Solana Pay with a program, e.g. when a PDA is the owner of the recipient account. Is there any reason not to change the default behavior to allow Token owners off the curve?

I believe an existing workaround is to have an owner on the curve and use the Approve instruction and delegate the full amount to the PDA. It's a bit clumsy though.