### PR TITLE
Kitepay added to Supporting Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Solana blockchain confirms transactions in less than a second and costs on a
 - Slope ([iOS](https://apps.apple.com/us/app/slope-wallet/id1574624530), [Android](https://play.google.com/store/apps/details?id=com.wd.wallet&hl=en_US&gl=US))
 - Crypto Please ([iOS](https://apps.apple.com/us/app/crypto-please/id1559625715), [Android](https://play.google.com/store/apps/details?id=com.pleasecrypto.flutter))
 - FTX ([iOS](https://apps.apple.com/us/app/ftx-trade-btc-eth-shib/id1095564685), [Android](https://play.google.com/store/apps/details?id=com.blockfolio.blockfolio))
+- Kitepay ([Android](https://play.google.com/store/apps/details?id=org.kitepay.app))
 
 
 **†** Includes support for [Transaction Requests](SPEC.md#specification-transaction-request)


### PR DESCRIPTION
[Kitepay🪁](https://kitepay.org) is a non-custodial Crypto wallet for effortless payments on Solana.

As [mentioned](https://github.com/solana-labs/solana-pay/pull/107#issuecomment-1079823296) by @jordansexton, we're submitting the App after release for review to get added to the Solana Pay Supporting Wallets List.