### PR TITLE
Remove redundant code

### DIFF
--- a/point-of-sale/src/server/core/connection.ts
+++ b/point-of-sale/src/server/core/connection.ts
@@ -1,4 +1,4 @@
 import { Connection } from '@solana/web3.js';
 import { CLUSTER_ENDPOINT } from './env';
 
-export const connection = new Connection(CLUSTER_ENDPOINT || 'https://api.devnet.solana.com', 'confirmed');
+export const connection = new Connection(CLUSTER_ENDPOINT, 'confirmed');


### PR DESCRIPTION
- [x] Remove the default value of connection because the variable CLUSTER_ENDPOINT already has a default value in the env file
