### PR TITLE
FIX: typo in docs, Soalna -> Solana

### DIFF
--- a/docs/src/core/transaction-request/OVERVIEW.mdx
+++ b/docs/src/core/transaction-request/OVERVIEW.mdx
@@ -16,7 +16,7 @@ import Card from '@site/src/components/Card';
 <section className="row">
     <Card link="https://www.pointer.gg/tutorials/solana-pay-irl-payments/944eba7e-82c6-4527-b55c-5411cdf63b23">
         <h2 className="text--truncate cardTitle">Taking payments IRL with Solana Pay</h2>
-        <p className="text--truncate cardDescription">Learn to take payments both online and IRL with Soalna Pay!</p>
+        <p className="text--truncate cardDescription">Learn to take payments both online and IRL with Solana Pay!</p>
     </Card>
 </section>
 


### PR DESCRIPTION
Fixes a typo I found when reading the docs for Solana Pay.