### PR TITLE
Replaced BaseURL by window.location

### DIFF
--- a/point-of-sale/src/client/components/contexts/ConfigProvider.tsx
+++ b/point-of-sale/src/client/components/contexts/ConfigProvider.tsx
@@ -5,7 +5,6 @@ import { Confirmations, Digits } from '../../types';
 
 export interface ConfigProviderProps {
     children: ReactNode;
-    baseURL: string;
     link?: URL;
     recipient: PublicKey;
     label: string;
@@ -21,7 +20,6 @@ export interface ConfigProviderProps {
 
 export const ConfigProvider: FC<ConfigProviderProps> = ({
     children,
-    baseURL,
     link,
     recipient,
     label,
@@ -37,7 +35,6 @@ export const ConfigProvider: FC<ConfigProviderProps> = ({
     return (
         <ConfigContext.Provider
             value={{
-                baseURL,
                 link,
                 recipient,
                 label,

--- a/point-of-sale/src/client/components/pages/App.tsx
+++ b/point-of-sale/src/client/components/pages/App.tsx
@@ -69,7 +69,6 @@ const App: FC<AppProps> & { getInitialProps(appContext: AppContext): Promise<App
                         <WalletProvider wallets={wallets} autoConnect={connectWallet}>
                             <WalletModalProvider>
                                 <ConfigProvider
-                                    baseURL={baseURL}
                                     link={link}
                                     recipient={recipient}
                                     label={label}

--- a/point-of-sale/src/client/hooks/useConfig.ts
+++ b/point-of-sale/src/client/hooks/useConfig.ts
@@ -3,7 +3,6 @@ import { createContext, ReactElement, useContext } from 'react';
 import { Confirmations, Digits } from '../types';
 
 export interface ConfigContextState {
-    baseURL: string;
     link: URL | undefined;
     recipient: PublicKey;
     label: string;

--- a/point-of-sale/src/client/hooks/useLinkWithQuery.ts
+++ b/point-of-sale/src/client/hooks/useLinkWithQuery.ts
@@ -1,11 +1,9 @@
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { createURLWithQuery } from '../utils/createURLWithQuery';
-import { useConfig } from './useConfig';
 
 export function useLinkWithQuery(pathname: string) {
-    const { baseURL } = useConfig();
     const { query } = useRouter();
 
-    return useMemo(() => String(createURLWithQuery(pathname, baseURL, query)), [pathname, baseURL, query]);
+    return useMemo(() => String(createURLWithQuery(pathname, query)), [pathname, query]);
 }

--- a/point-of-sale/src/client/hooks/useNavigateWithQuery.ts
+++ b/point-of-sale/src/client/hooks/useNavigateWithQuery.ts
@@ -8,19 +8,19 @@ export interface NavigateOptions {
 }
 
 export function useNavigateWithQuery() {
-    const { baseURL } = useConfig();
     const router = useRouter();
     const { query } = router;
 
     return useCallback(
         (pathname: string, replace = false) => {
-            const url = String(createURLWithQuery(pathname, baseURL, query));
+            const origin = window.location.protocol + '//' + window.location.host;
+            const url = String(createURLWithQuery(pathname, origin, query));
             if (replace) {
                 router.replace(url);
             } else {
                 router.push(url);
             }
         },
-        [baseURL, query, router]
+        [query, router]
     );
 }

--- a/point-of-sale/src/client/hooks/useNavigateWithQuery.ts
+++ b/point-of-sale/src/client/hooks/useNavigateWithQuery.ts
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { createURLWithQuery } from '../utils/createURLWithQuery';
-import { useConfig } from './useConfig';
 
 export interface NavigateOptions {
     replace: boolean;
@@ -13,8 +12,7 @@ export function useNavigateWithQuery() {
 
     return useCallback(
         (pathname: string, replace = false) => {
-            const origin = window.location.protocol + '//' + window.location.host;
-            const url = String(createURLWithQuery(pathname, origin, query));
+            const url = String(createURLWithQuery(pathname, query));
             if (replace) {
                 router.replace(url);
             } else {

--- a/point-of-sale/src/client/utils/createURLWithQuery.ts
+++ b/point-of-sale/src/client/utils/createURLWithQuery.ts
@@ -1,7 +1,7 @@
 import { ParsedUrlQuery } from 'querystring';
 
-export function createURLWithQuery(url: string | URL, base: string | URL, query: ParsedUrlQuery): URL {
-    url = new URL(url, base);
+export function createURLWithQuery(path: string | URL, query: ParsedUrlQuery): URL {
+    const url = new URL(path, window.location.protocol + '//' + window.location.host);
 
     for (const [key, value] of Object.entries(query)) {
         if (value) {


### PR DESCRIPTION
When using "navigate" after payment has been processed, the BaseURL is reset and it ends up to navigating to default location (which is set to "localhost" in App.ts).