### PR TITLE
BackButton should be disabled once clicked

### DIFF
--- a/examples/point-of-sale/src/client/components/buttons/BackButton.tsx
+++ b/examples/point-of-sale/src/client/components/buttons/BackButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes, ReactNode } from 'react';
+import React, { FC, HTMLAttributes, MouseEventHandler, ReactNode, useCallback, useState } from 'react';
 import { BackIcon } from '../images/BackIcon';
 import css from './BackButton.module.css';
 
@@ -8,8 +8,17 @@ export interface BackButtonProps {
 }
 
 export const BackButton: FC<BackButtonProps> = ({ children, onClick }) => {
+    const [disabled, setDisabled] = useState(false);
+    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+        (event) => {
+            setDisabled(true);
+            if (onClick) onClick(event);
+        },
+        [onClick]
+    );
+
     return (
-        <button className={css.button} type="button" onClick={onClick}>
+        <button className={css.button} type="button" onClick={handleClick} disabled={disabled}>
             <BackIcon />
             {children}
         </button>


### PR DESCRIPTION
In order to avoid double click and to be clear that the button has been pressed, it should be disabled once clicked on.