### PR TITLE
Sdk updates  for proposed 1.1 spec

### DIFF
--- a/core/src/encodeURL.ts
+++ b/core/src/encodeURL.ts
@@ -1,5 +1,5 @@
 import { SOLANA_PROTOCOL } from './constants.js';
-import type { Amount, Label, Memo, Message, Recipient, References, SPLToken } from './types.js';
+import type { Amount, Label, Memo, Message, Recipient, References, SPLToken, Redirect } from './types.js';
 
 /**
  * Fields of a Solana Pay transaction request URL.
@@ -31,6 +31,8 @@ export interface TransferRequestURLFields {
     message?: Message;
     /** `memo` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#memo). */
     memo?: Memo;
+    /** `redirect` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC1.1.md#redirect). */
+    redirect?: Redirect;
 }
 
 /**
@@ -68,6 +70,7 @@ function encodeTransferRequestURL({
     label,
     message,
     memo,
+    redirect,
 }: TransferRequestURLFields): URL {
     const pathname = recipient.toBase58();
     const url = new URL(SOLANA_PROTOCOL + pathname);
@@ -100,6 +103,10 @@ function encodeTransferRequestURL({
 
     if (memo) {
         url.searchParams.append('memo', memo);
+    }
+
+    if (redirect) {
+        url.searchParams.append('redirect', redirect.toString());
     }
 
     return url;

--- a/core/src/encodeURL.ts
+++ b/core/src/encodeURL.ts
@@ -36,15 +36,29 @@ export interface TransferRequestURLFields {
 }
 
 /**
+ * Fields of a Solana Pay message sign request URL.
+ */
+export interface MessageSignRequestURLFields {
+    /** `link` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/message-signing-spec.md#link). */
+    link: URL;
+}
+
+/**
  * Encode a Solana Pay URL.
  *
  * @param fields Fields to encode in the URL.
  */
-export function encodeURL(fields: TransactionRequestURLFields | TransferRequestURLFields): URL {
-    return 'link' in fields ? encodeTransactionRequestURL(fields) : encodeTransferRequestURL(fields);
+export function encodeURL(
+    fields: TransactionRequestURLFields | TransferRequestURLFields | MessageSignRequestURLFields
+): URL {
+    return 'link' in fields ? encodeTransactionOrMessageSignRequestURL(fields) : encodeTransferRequestURL(fields);
 }
 
-function encodeTransactionRequestURL({ link, label, message }: TransactionRequestURLFields): URL {
+function encodeTransactionOrMessageSignRequestURL({
+    link,
+    label,
+    message,
+}: TransactionRequestURLFields | (MessageSignRequestURLFields & { label: undefined; message: undefined })): URL {
     // Remove trailing slashes
     const pathname = link.search
         ? encodeURIComponent(String(link).replace(/\/\?/, '?'))

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -25,5 +25,8 @@ export type Message = string;
 /** `memo` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#memo). */
 export type Memo = string;
 
+/** `redirect` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC1.1.md#redirect). */
+export type Redirect = URL;
+
 /** `link` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#link). */
 export type Link = URL;


### PR DESCRIPTION
Marking as draft because we'll want to coordinate this release so we don't confuse application developers. Maybe a 1.1 or alpha branch?

This PR adds the spec changes to support the proposed/alpha 1.1 spec

- Redirect is added as an optional parameter on transfer request URLs. Note that for transaction requests redirects are part of the POST response which is out of scope for the SDK.
- A new `MessageSignRequestURLFields` is added with just a `link` field. Internally `encodeURL` encodes it in the same way as a transaction request

Notes:

- No SDK changes are made for transaction request error handling, because again they're just part of the POST response
- Should we deprecate the `label` and `message` fields of `TransactionRequestURLFields`? They're not in the spec and I haven't included them in the fields for message signing requests. I think they're superseded by `label` in the GET response, and `message` in the POST response. If we eventually remove them we could simplify the encoding since transaction request and message signing request would be the same structure. 
- I think using `encodeTransactionOrMessageSignRequestURL` is kinda hacky, but we can't differentiate `TransactionRequestURLFields` from `MessageSignRequestURLFields` at a typescript level