### PR TITLE
Fixed Transaction Requests link

### DIFF
--- a/examples/point-of-sale/README.md
+++ b/examples/point-of-sale/README.md
@@ -115,7 +115,7 @@ When you're done, it should look like this:
 
 ## Using Transaction Requests
 
-[Transaction Requests](../SPEC.md#specification-transaction-request) are a new feature in Solana Pay.
+[Transaction Requests](https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#specification-transaction-request) are a new feature in Solana Pay.
 
 In the [`client/components/pages/App.tsx`](https://github.com/solana-labs/solana-pay/blob/master/examples/point-of-sale/src/client/components/pages/App.tsx) file, toggle these lines:
 


### PR DESCRIPTION
In the [README.md](https://github.com/akshatcoder-hash/solana-pay/edit/master/examples/point-of-sale/README.md) for point-of-sale app, the link to the feature of transaction requests was linked to a file that was not present in the same folder.
It was present in the SPEC.md.

![image](https://user-images.githubusercontent.com/69577224/224483347-e109067b-782b-4889-ad51-c747a0df94c3.png)
 