### PR TITLE
Add missing commits to master

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -82,7 +82,7 @@ const config = {
                         items: [
                             {
                                 label: 'Discord',
-                                href: 'https://discord.com/invite/solana',
+                                href: 'https://solana.com/discord',
                             },
                             {
                                 label: 'Twitter',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -81,8 +81,8 @@ const config = {
                         title: 'Community',
                         items: [
                             {
-                                label: 'Discord',
-                                href: 'https://solana.com/discord',
+                                label: 'Stack Exchange',
+                                href: 'https://solana.stackexchange.com',
                             },
                             {
                                 label: 'Twitter',


### PR DESCRIPTION
PRs #207  and #208 were made against `docs` and not master. This PR pulls in their commits so master and docs match correctly. 