### PR TITLE
doc: Add eCommerce reference implementation section to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,20 @@ Here are some [Solana Pay hackathon ideas](https://www.figma.com/community/file/
 
 To get as many merchants accepting payments on Solana as possible we need to provide easy ways to set up Solana Pay on all eCommerce platforms.
 
-Solana Labs has started a reference implementation for Shopify which you can see [here](https://github.com/solana-labs/solana-pay/blob/shopify/shopify) to get a sense of how this might work.
-
-Here are some of the top eCommerce platforms that we're looking to integrate to:
+Here are some of the top eCommerce platforms that we're looking to integrate with:
 
 - WooCommerce
 - Magento
 - BigCommerce
 - Wix
 - Squarespace
+
+#### Reference Implementations
+
+Solana Labs and the community have the following reference implementations, which you can check out to get an idea of how to add Solana Pay to eCommerce platforms.
+
+- [Shopify](https://github.com/solana-labs/solana-pay/blob/shopify/shopify)
+- [WooCommerce](https://github.com/t4top/solana-pay-for-woocommerce)
 
 ### Other possible projects
 


### PR DESCRIPTION
- Resolves https://github.com/solana-foundation/solana-pay/issues/206 by adding a link to WooCommerce reference implementation in the ReadMe 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'Reference Implementations' section to `README.md` with links to Shopify and WooCommerce implementations.
> 
>   - **Documentation**:
>     - Adds 'Reference Implementations' section to `README.md` under 'eCommerce Platform Integrations'.
>     - Includes links to Shopify and WooCommerce reference implementations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fsolana-pay&utm_source=github&utm_medium=referral)<sup> for 66296db76bc16c49a322dc7758b301255fdde4ae. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->