### PR TITLE
refactor: split send_and_confirm_transaction into send + confirm

### DIFF
--- a/rust/crates/core/src/client/send.rs
+++ b/rust/crates/core/src/client/send.rs
@@ -99,10 +99,14 @@ pub async fn send_sol(
         .ok_or_else(|| Error::Config("Signer not found in transaction".to_string()))?;
     tx.signatures[signer_index] = sig;
 
-    // Send and confirm
+    // Send TX
     let signature = rpc
-        .send_and_confirm_transaction(&tx)
+        .send_transaction(&tx)
         .map_err(|e| Error::Config(format!("Transaction failed: {e}")))?;
+
+    // Confirm TX
+    rpc.confirm_transaction(&signature)
+        .map_err(|e| Error::Config(format!("Confirmation failed: {e}")))?;
 
     Ok(SendResult {
         signature: signature.to_string(),


### PR DESCRIPTION
Refactor transaction flow by splitting send_and_confirm_transaction into separate send and confirm steps.

This change improves code clarity and provides better control over the transaction lifecycle.