### PR TITLE
fix: expose PDB assets to cross release builds

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -135,6 +135,10 @@ jobs:
       - name: Build PDB frontend
         run: cd ../pdb && pnpm install --frozen-lockfile && pnpm build
 
+      - name: Copy PDB frontend for cross
+        if: matrix.use-cross
+        run: cp -R ../pdb/dist pdb-dist
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -149,10 +153,19 @@ jobs:
           key: release-${{ matrix.target }}
 
       - name: Build
+        if: ${{ !matrix.use-cross }}
         run: >-
-          ${{ matrix.use-cross && 'cross' || 'cargo' }} build --release
+          cargo build --release
           --target ${{ matrix.target }}
-          ${{ matrix.use-cross && '--features vendored-openssl' || '' }}
+
+      - name: Build (cross)
+        if: matrix.use-cross
+        env:
+          PAY_PDB_DIST: /project/pdb-dist
+        run: >-
+          cross build --release
+          --target ${{ matrix.target }}
+          --features vendored-openssl
 
       - name: Package (unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- copy built PDB assets into the Rust workspace for cross builds
- set PAY_PDB_DIST to the cross container path for the aarch64 Linux release build
- keep native release builds on the existing cargo path

## Test Plan
- ruby -e 'require "yaml"; YAML.load_file("../.github/workflows/release-cli.yml")'

Fixes the failed aarch64-unknown-linux-gnu release job in https://github.com/solana-foundation/pay/actions/runs/25136237699