### PR TITLE
ci: fix docker image

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -17,6 +17,9 @@ RUN git config --global url."https://github.com/".insteadOf "git@github.com:" &&
 
 COPY . .
 
+ARG PAY_PDB_ALLOW_PLACEHOLDER
+ENV PAY_PDB_ALLOW_PLACEHOLDER=${PAY_PDB_ALLOW_PLACEHOLDER}
+
 RUN cargo build --release --features gcp_kms
 
 RUN cp target/release/pay /usr/local/bin/pay


### PR DESCRIPTION
## Summary
- Wire a `PAY_PDB_ALLOW_PLACEHOLDER` build-arg into `rust/Dockerfile` so the `cargo build` step in the rust-only build context can opt into the placeholder PDB asset.
- Unblocks the agent-gateway `Docker Publish` workflow (https://github.com/solana-foundation/agent-gateway/actions/runs/25242322161/job/74020321084), which builds with only `rust/` as the docker context and therefore can't supply `pdb/dist`.

## Why
`crates/pdb/build.rs` panics when `pdb/dist` is missing unless `PAY_PDB_ALLOW_PLACEHOLDER=1` is set. The Dockerfile copies only the rust workspace, so the placeholder path is the only viable option for that workflow.

## Test plan
- [ ] Re-run agent-gateway's Docker Publish (build mode) with the matching `--build-arg PAY_PDB_ALLOW_PLACEHOLDER=1` and confirm the build succeeds.
- [ ] Verify default builds (without the arg) still fail loudly when `pdb/dist` is absent (no behavior change for existing callers).