### PR TITLE
fix: update Codex launcher permission flags

### DIFF
--- a/rust/crates/cli/src/commands/codex.rs
+++ b/rust/crates/cli/src/commands/codex.rs
@@ -75,6 +75,8 @@ fn build_codex_args(
             "mcp_servers.pay.enabled_tools={}",
             toml_string_array(PAY_MCP_ENABLED_TOOLS)
         ),
+        "-c".to_string(),
+        config_string("mcp_servers.pay.default_tools_approval_mode", "approve"),
     ];
 
     // Pass config to MCP server via env.
@@ -101,7 +103,10 @@ fn build_codex_args(
         "model_instructions_file",
         &instructions_path.to_string_lossy(),
     ));
-    args.push("--full-auto".to_string());
+    args.push("--sandbox".to_string());
+    args.push("workspace-write".to_string());
+    args.push("--ask-for-approval".to_string());
+    args.push("never".to_string());
     args.extend(extra_args.iter().cloned());
     args
 }
@@ -241,12 +246,25 @@ mod tests {
             &r#"mcp_servers.pay.enabled_tools=["curl","search_catalog","list_catalog","get_catalog_entry","get_balance","topup","create_skill"]"#.to_string()
         ));
         assert!(
+            args.contains(&r#"mcp_servers.pay.default_tools_approval_mode="approve""#.to_string())
+        );
+        assert!(
             args.contains(&r#"mcp_servers.pay.env={PAY_ACTIVE_ACCOUNT="default"}"#.to_string())
         );
         assert!(args.contains(
             &r#"model_instructions_file="C:\\Users\\me\\AppData\\Local\\Temp\\pay instructions.md""#
                 .to_string()
         ));
+        assert!(!args.contains(&"--full-auto".to_string()));
+        assert_eq!(
+            args[args.len() - 4..],
+            [
+                "--sandbox",
+                "workspace-write",
+                "--ask-for-approval",
+                "never"
+            ]
+        );
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- Replace the deprecated `--full-auto` Codex launcher flag with explicit sandboxed no-prompt permission flags.
- Configure Pay MCP tools as approved by default so `pay codex` keeps the previous no-prompt MCP UX on current Codex CLI versions.
- Update inline launcher argument tests to cover the new flags and MCP approval config.

Fixes #338.

## Background

[Codex CLI 0.128.0 ](https://github.com/openai/codex/releases/tag/rust-v0.128.0) no longer accepts `--full-auto` for the interactive TUI path. As a result, `pay codex` / `pay --sandbox codex` fails before Codex starts:

```text
error: unexpected argument '--full-auto' found
```

`pay codex` should continue launching Codex with the Pay MCP server, enabled Pay MCP tools, and injected Pay instructions, but without relying on obsolete Codex CLI flags.

## Changes

The launcher now passes explicit Codex permission flags instead of `--full-auto`:

```bash
--sandbox workspace-write --ask-for-approval never
```

This keeps the Codex workspace sandbox enabled while avoiding shell approval prompts for actions allowed within that sandbox. It intentionally does not use:

```bash
--dangerously-bypass-approvals-and-sandbox
```

Codex shell approvals and MCP tool approvals are separate layers, so this PR also injects:

```toml
mcp_servers.pay.default_tools_approval_mode = "approve"
```

That avoids Codex MCP approval prompts for the enabled Pay MCP tools and preserves the previous no-prompt `pay codex` UX.

## Security / behavior notes

`default_tools_approval_mode = "approve"` removes Codex's MCP confirmation prompt for enabled Pay MCP tools, including tools such as `curl`, `topup`, and `create_skill`.

This does not disable the Codex workspace sandbox, and it does not bypass wallet or payment authorization. It only controls Codex's MCP tool confirmation layer.

## Validation

```bash
cargo fmt
cargo test -p pay codex
```

I also smoke-tested `pay --sandbox codex` with a fake `codex` binary and confirmed that the generated args include:

```text
--sandbox workspace-write --ask-for-approval never
```

and:

```toml
mcp_servers.pay.default_tools_approval_mode = "approve"
```

## Reference

> Deprecated --full-auto while steering users toward explicit permission profiles and trust flows.

https://github.com/openai/codex/releases/tag/rust-v0.128.0