### PR TITLE
ux: clarify Touch ID requirement for Keychain

### DIFF
--- a/rust/crates/cli/src/commands/account/new.rs
+++ b/rust/crates/cli/src/commands/account/new.rs
@@ -291,7 +291,7 @@ pub fn pick_backend() -> pay_core::Result<String> {
     #[cfg(target_os = "macos")]
     let options = [Opt {
         id: "keychain",
-        label: "macOS Keychain (Touch ID)".into(),
+        label: "macOS Keychain (requires Touch ID)".into(),
     }];
 
     #[cfg(target_os = "linux")]

--- a/rust/crates/keystore/src/macos/mod.rs
+++ b/rust/crates/keystore/src/macos/mod.rs
@@ -38,7 +38,7 @@ impl AuthGate for TouchId {
             if is_user_cancel(&err) {
                 Err(Error::AuthDenied(err))
             } else {
-                Err(Error::Backend(err))
+                Err(Error::Backend(touch_id_unavailable_guidance(&err)))
             }
         }
     }
@@ -55,6 +55,12 @@ impl AuthGate for TouchId {
             .map(|out| String::from_utf8_lossy(&out.stdout).trim() == "yes")
             .unwrap_or(false)
     }
+}
+
+fn touch_id_unavailable_guidance(err: &str) -> String {
+    format!(
+        "{err}\n\nTouch ID is required to use macOS Keychain with pay. Make sure Touch ID is available and configured on this Mac, then try again."
+    )
 }
 
 // ── Apple Keychain store ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Clarify that the macOS Keychain backend requires Touch ID during account setup.
- Add a short guidance message when Touch ID authentication fails for non-cancel backend errors.
- Keep the existing backend behavior unchanged.

Fixes #340.

## Background

A user reported getting stuck while running `pay setup` in a macOS environment where Touch ID was not available. The setup prompt currently says:

```text
macOS Keychain (Touch ID)
```

That mentions Touch ID, but it can read like a backend description rather than a hard requirement. Since pay's macOS Keychain backend uses Touch ID/biometrics for authentication, the setup experience is clearer if the requirement is explicit.

## Changes

The backend picker label now says:

```text
macOS Keychain (requires Touch ID)
```

For non-cancel Touch ID authentication failures, the original error is preserved and followed by guidance:

```text
Touch ID is required to use macOS Keychain with pay. Make sure Touch ID is available and configured on this Mac, then try again.
```

## Notes

This intentionally does not:

- hide the macOS Keychain option when Touch ID is unavailable
- change the Swift helper from `.deviceOwnerAuthenticationWithBiometrics` to `.deviceOwnerAuthentication`
- alter the underlying authentication/security behavior

This PR only improves the setup/authentication messaging.

## Validation

```bash
cargo fmt --check
cargo test -p pay setup
```