### PR TITLE
fix: make endpoint resource optional to prevent downstream parsing errors

### DIFF
--- a/rust/crates/cli/src/commands/skills/search.rs
+++ b/rust/crates/cli/src/commands/skills/search.rs
@@ -279,11 +279,14 @@ fn print_condensed(hits: &[SearchHit], services: &[String]) {
 fn print_resource_groups(hits: &[&SearchHit]) {
     let mut current_resource = String::new();
     for hit in hits {
-        if hit.resource != current_resource && !hit.resource.is_empty() {
+        if let Some(hit_resource) = hit.resource.as_deref()
+            && hit_resource != current_resource
+            && !hit_resource.is_empty()
+        {
             if !current_resource.is_empty() {
                 eprintln!();
             }
-            current_resource = hit.resource.clone();
+            current_resource = hit_resource.to_string();
             eprintln!("  {} {}", "resource:".dimmed(), current_resource.bold());
         }
         print_endpoint(hit);
@@ -382,7 +385,7 @@ mod tests {
             method: method.to_string(),
             path: path.to_string(),
             full_path: String::new(),
-            resource: resource.to_string(),
+            resource: Some(resource.to_string()),
             description: description.to_string(),
             pricing: metered
                 .then(|| json!({ "dimensions": [{ "tiers": [{ "price_usd": 1.0 }] }] })),
@@ -459,7 +462,12 @@ mod tests {
         assert_eq!(refreshed.hits.len(), 2);
         assert!(refreshed.hits.iter().all(|hit| !hit.method.is_empty()));
         assert!(refreshed.hits.iter().all(|hit| !hit.path.is_empty()));
-        assert!(refreshed.hits.iter().all(|hit| !hit.resource.is_empty()));
+        assert!(
+            refreshed
+                .hits
+                .iter()
+                .all(|hit| hit.resource.as_deref().unwrap_or("").is_empty())
+        );
     }
 
     #[test]
@@ -514,7 +522,7 @@ mod tests {
                 .contains("/v2/projects/gateway-402/queries")
         );
         assert_eq!(grouped[1].service, "solana-foundation/google/vision");
-        assert_eq!(grouped[1].endpoints[0].resource, "images");
+        assert_eq!(grouped[1].endpoints[0].resource, Some("images".to_string()));
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/skills/search.rs
+++ b/rust/crates/cli/src/commands/skills/search.rs
@@ -462,12 +462,8 @@ mod tests {
         assert_eq!(refreshed.hits.len(), 2);
         assert!(refreshed.hits.iter().all(|hit| !hit.method.is_empty()));
         assert!(refreshed.hits.iter().all(|hit| !hit.path.is_empty()));
-        assert!(
-            refreshed
-                .hits
-                .iter()
-                .all(|hit| hit.resource.as_deref().unwrap_or("").is_empty())
-        );
+        assert_eq!(refreshed.hits[0].resource.as_deref(), Some("jobs"));
+        assert_eq!(refreshed.hits[1].resource.as_deref(), Some("datasets"));
     }
 
     #[test]

--- a/rust/crates/core/src/skills/mod.rs
+++ b/rust/crates/core/src/skills/mod.rs
@@ -907,7 +907,14 @@ pub async fn ensure_endpoints(catalog: &mut Catalog, service_name: &str) -> Resu
     }
 
     let raw = fetch_url(&detail_url).await?;
-    let detail = parse_detail(&raw)?;
+    let detail = match parse_detail(&raw) {
+        Ok(detail) => detail,
+        Err(e) => {
+            tracing::warn!(url = %detail_url, "Failed to parse provider detail JSON: {e}");
+            return Err(e);
+        }
+    };
+
     let _ = std::fs::create_dir_all(&cache_dir);
     let _ = std::fs::write(&cache_file, &raw);
 

--- a/rust/crates/core/src/skills/mod.rs
+++ b/rust/crates/core/src/skills/mod.rs
@@ -107,7 +107,7 @@ pub struct Endpoint {
     #[serde(default)]
     pub full_path: String,
     #[serde(default)]
-    pub resource: String,
+    pub resource: Option<String>,
     #[serde(default)]
     pub description: String,
     #[serde(default)]
@@ -127,7 +127,7 @@ pub struct SearchHit {
     pub path: String,
     pub full_path: String,
     pub description: String,
-    pub resource: String,
+    pub resource: Option<String>,
     pub pricing: Option<serde_json::Value>,
     pub metered: bool,
 }
@@ -148,7 +148,7 @@ pub struct EndpointHit {
     pub url: String,
     pub path: String,
     pub description: String,
-    pub resource: String,
+    pub resource: Option<String>,
     pub metered: bool,
 }
 
@@ -302,7 +302,7 @@ pub fn search(catalog: &Catalog, query: Option<&str>, category: Option<&str>) ->
                 path: String::new(),
                 full_path: String::new(),
                 description: svc.meta.description.clone(),
-                resource: String::new(),
+                resource: None,
                 pricing: None,
                 metered: svc.has_metering,
             });
@@ -574,7 +574,10 @@ fn score_service_for_query(
         && svc.endpoints.iter().any(|ep| {
             let haystack = format!(
                 "{} {} {} {}",
-                ep.method, ep.path, ep.resource, ep.description
+                ep.method,
+                ep.path,
+                ep.resource.as_deref().unwrap_or(""),
+                ep.description
             )
             .to_lowercase();
             !query_lower.is_empty() && haystack.contains(query_lower)
@@ -605,7 +608,13 @@ fn score_service_for_query(
 
 fn endpoint_term_matches(svc: &Service, term: &str) -> bool {
     svc.endpoints.iter().any(|ep| {
-        let haystack = format!("{} {} {}", ep.path, ep.resource, ep.description).to_lowercase();
+        let haystack = format!(
+            "{} {} {}",
+            ep.path,
+            ep.resource.as_deref().unwrap_or(""),
+            ep.description
+        )
+        .to_lowercase();
         contains_query_term(&haystack, term)
     })
 }
@@ -677,10 +686,13 @@ pub fn service_detail(catalog: &Catalog, service_name: &str) -> Option<ServiceDe
 
     let mut groups: BTreeMap<String, (u32, u32, Vec<String>)> = BTreeMap::new();
     for ep in &svc.endpoints {
-        let resource = if ep.resource.is_empty() {
+        let Some(resource) = &ep.resource else {
+            continue;
+        };
+        let resource = if resource.is_empty() {
             "(default)"
         } else {
-            &ep.resource
+            resource
         };
         let entry = groups
             .entry(resource.to_string())
@@ -720,7 +732,13 @@ pub fn resource_endpoints(
     let endpoints: Vec<Endpoint> = svc
         .endpoints
         .iter()
-        .filter(|ep| ep.resource.eq_ignore_ascii_case(resource_name))
+        .filter(|ep| {
+            if let Some(resource) = &ep.resource {
+                resource.eq_ignore_ascii_case(resource_name)
+            } else {
+                false
+            }
+        })
         .cloned()
         .collect();
 
@@ -2324,7 +2342,7 @@ mod tests {
             method: "GET".to_string(),
             path: "test".to_string(),
             full_path: String::new(),
-            resource: String::new(),
+            resource: None,
             description: "test".to_string(),
             pricing: None,
         }];
@@ -2396,7 +2414,7 @@ mod tests {
             method: "GET".to_string(),
             path: "old".to_string(),
             full_path: String::new(),
-            resource: String::new(),
+            resource: None,
             description: "old endpoint".to_string(),
             pricing: None,
         }];

--- a/rust/crates/mcp/src/tools/get_catalog_entry.rs
+++ b/rust/crates/mcp/src/tools/get_catalog_entry.rs
@@ -142,7 +142,7 @@ mod tests {
             path: "v1/search".to_string(),
             full_path: String::new(),
             description: "Search records by keyword with pagination".to_string(),
-            resource: "search".to_string(),
+            resource: Some("search".to_string()),
             pricing: Some(serde_json::json!({
                 "dimensions": [
                     {

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -67,8 +67,8 @@ struct EndpointEntry {
     method: String,
     path: String,
     url: String,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    resource: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource: Option<String>,
     description: String,
     metered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -290,7 +290,7 @@ fn score_endpoint_for_query(
     terms: &[String],
 ) -> u32 {
     let path = ep.path.to_lowercase();
-    let resource = ep.resource.to_lowercase();
+    let resource = ep.resource.as_deref().unwrap_or("").to_lowercase();
     let description = ep.description.to_lowercase();
     let haystack = format!("{} {} {} {}", ep.method, path, resource, description).to_lowercase();
     let mut score = if !query_lower.is_empty() && haystack.contains(query_lower) {
@@ -450,7 +450,7 @@ mod tests {
                 method: "POST".to_string(),
                 path: "v1/search".to_string(),
                 full_path: String::new(),
-                resource: "search".to_string(),
+                resource: Some("search".to_string()),
                 description: "Search indexed documents".to_string(),
                 pricing: Some(serde_json::json!({
                     "dimensions": [{ "tiers": [{ "price_usd": 0.01 }, { "price_usd": 0.02 }] }]
@@ -1381,7 +1381,7 @@ mod tests {
             method: method.to_string(),
             path: path.to_string(),
             full_path: String::new(),
-            resource: resource.to_string(),
+            resource: Some(resource.to_string()),
             description: description.to_string(),
             pricing: (price_usd > 0.0).then(|| {
                 serde_json::json!({


### PR DESCRIPTION
`pay catalog build` would generate `endpoints.path[i].resource == null` if the openapi spec has no `tags` or an endpoint. 
Later, when this file is parsed via `pay skills search`,  the parsed type had resource required, causing that skill to be skipped.
This would make discoverability of skills worse, because any containing no `tags` in the openapi spec would not be searchable