### PR TITLE
docs(aggregators): add AlgoVoi multi-protocol facilitator

### DIFF
--- a/aggregators/algovoi.md
+++ b/aggregators/algovoi.md
@@ -1,0 +1,48 @@
+---
+name: algovoi
+title: AlgoVoi multi-protocol facilitator
+url: https://algovoi.co.uk
+contact: chopmob@gmail.com
+description: Multi-chain x402 + MPP + AP2 facilitator covering seven mainnet networks (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo). Routes Solana via Circle CCTP V2 (~50s, native USDC) and Algorand + Stellar via Allbridge Core. Stellar destination went live 2026-05-05; first mainnet bridge from Base settled in ~2 minutes to canonical Circle USDC at the merchant's classic Stellar address.
+catalog_url: https://api.algovoi.co.uk/.well-known/pay-skills.json
+---
+
+# AlgoVoi
+
+AlgoVoi is a hosted x402 facilitator that lets API providers and AI agents accept stablecoin payments without managing on-chain infrastructure or destination-chain wallets directly. The same gateway speaks the [x402 Payment Protocol](https://x402.org), [Machine Payments Protocol (MPP)](https://github.com/circle-platform/mpp), and [Agent Payments Protocol (AP2)](https://github.com/google-agentic-commerce/AP2) — providers pick whichever protocol matches their client, and AlgoVoi handles verification, settlement, and webhooks.
+
+## What this aggregator entry exposes
+
+Live AlgoVoi tenants opt their `resource_definitions` into the public catalog by setting `is_active=true` on the resource and `mode=live, status=active` on the tenant. The aggregator endpoint at `catalog_url` returns those entries in the pay.sh `version: 2` envelope shape — `provider_count`, `providers[]`, strong `ETag`, `Cache-Control: public, max-age=60`, and conditional `If-None-Match` support so `pay skills sync` can poll cheaply.
+
+Each provider entry includes:
+
+- `fqn` — `algovoi/<tenant_short_id>/<resource_id>` triple-namespaced for stable identity across tenants.
+- `service_url` — public AlgoVoi-hosted resource path (`https://api.algovoi.co.uk/r/<tenant>/<resource>`).
+- `min_price_usd` / `max_price_usd` — derived from `amount_microunits` for USDC across all three encoding formats (Algorand ASA `31566704`, Solana mint `EPjFWdd5…`, Stellar classic issuer `GA5ZSEJ…` / 7dp scaling).
+- `category` — heuristic over the resource slug (`agent`, `rpc`, `data`, `messaging`, fallback `payment-gated-resource`).
+- `sha` — deterministic 16-char content fingerprint, stable across regenerations when nothing has changed.
+
+Test-mode tenants and any non-mainnet networks are filtered out before serialisation; the public catalog is production-grade only.
+
+## xChain — pay from MetaMask, settle on the destination chain
+
+Every AlgoVoi-protected resource on Algorand, Solana, or Stellar mainnet exposes a MetaMask payment path. Customers holding USDC on any of seven supported EVM source chains (Base, Arbitrum, Polygon, Optimism, Ethereum, BNB Chain, Avalanche) can pay through pay.sh's CLI without ever installing a destination-chain wallet — AlgoVoi bridges the USDC end-to-end and verifies delivery before unlocking the resource.
+
+- **Solana** — Circle CCTP V2 Fast Transfer (default). ~50s end-to-end, zero pool slippage, native Circle USDC on both sides.
+- **Algorand** — Allbridge Core delivers Allbridge-wrapped USDCa (ASA `31566704`) to a deterministically-derived LogicSig address, then settles native to the merchant.
+- **Stellar** (live since 2026-05-05) — Allbridge Core's swap-and-bridge route invokes a Soroban swap pool that auto-converts to canonical Circle USDC at the classic issuer (`GA5ZSEJ…`) and credits the merchant's `G…` address via a normal `account_credited` effect. **Any Stellar wallet supports the asset** — no Soroban-aware wallet required.
+
+CCTP V2 will be added as a second protocol on Stellar once Circle ships Stellar mainnet contracts publicly (currently testnet-only).
+
+## Wallet expectations
+
+AlgoVoi is non-custodial — merchants hold their own destination-chain keys. For pay.sh users paying AlgoVoi-protected endpoints, the local biometric signing flow (Touch ID / Windows Hello / GNOME Keyring) is the recommended pattern; AlgoVoi never sees the customer's private key.
+
+## Stable contact + canonical URLs
+
+- Catalog: <https://api.algovoi.co.uk/.well-known/pay-skills.json>
+- Discovery (a2a / x402): <https://api.algovoi.co.uk/.well-known/agent-card.json>
+- Security policy: <https://api.algovoi.co.uk/.well-known/security.txt>
+- Documentation: <https://docs.algovoi.co.uk/concepts/xchain>
+- Operator email: <chopmob@gmail.com>


### PR DESCRIPTION
## What this adds

A first **aggregator** entry — `aggregators/algovoi.md` — covering AlgoVoi, a multi-protocol x402 + MPP + AP2 facilitator that has been running in production across seven mainnet networks since 2026-04. The entry's `catalog_url` points to a live pay.sh-compatible catalog endpoint that auto-imports active resource definitions from every AlgoVoi-onboarded tenant.

## Why this is timely

`pay v1.0.0` shipped 2026-05-05. AlgoVoi shipped Stellar mainnet xChain the same day — the first non-Solana, non-Algorand destination on the AlgoVoi xChain pipeline. Both the AlgoVoi catalog endpoint and the Stellar destination are running production traffic today, so the aggregator entry is real and queryable as soon as this lands.

## What pay.sh gets

- **Aggregator entry** that conforms to the [`AggregatorFrontmatter` schema in `rust/crates/types/src/registry.rs`](https://github.com/solana-foundation/pay/blob/main/rust/crates/types/src/registry.rs) — `name`, `title`, `url`, `contact`, `description`, `catalog_url`.
- **Live `catalog_url`** at https://api.algovoi.co.uk/.well-known/pay-skills.json returning a valid `version: 2` envelope (`provider_count`, `affiliate_count`, `aggregator_count`, `providers`, `affiliates`, `aggregators`).
- **Strong `ETag` + `Cache-Control: public, max-age=60`** with conditional `GET` and `HEAD` support via `If-None-Match` — pay.sh's `pay skills sync` workflow gets cheap 304s on unchanged catalog state.
- **Per-provider entries** populated from active `resource_definitions` on live AlgoVoi tenants. Each entry includes `fqn` (`algovoi/<tenant>/<resource>`), `service_url`, `category` (heuristic: `agent`, `rpc`, `data`, `messaging`, fallback `payment-gated-resource`), `endpoint_count`, `has_metering`, `has_free_tier`, optional `min_price_usd`/`max_price_usd` for USDC-priced endpoints, and a deterministic 16-char `sha` content fingerprint.
- **USDC pricing inference** across all three chain-specific encoding formats:
  - Algorand: ASA `31566704`, 6dp
  - Solana: mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, 6dp
  - Stellar: classic issuer `GA5ZSEJ…`, 7dp (auto-scaled)
- **Filtering**: only `is_active = true` resources on `mode = 'live', status = 'active'` tenants on the seven-network mainnet allowlist (testnets explicitly excluded).
- **Graceful degradation**: a single bad row never poisons the catalog — it's logged and skipped, the rest renders.

## How to verify

```sh
# Envelope shape + counts
curl -s https://api.algovoi.co.uk/.well-known/pay-skills.json | jq '{version, provider_count, base_url}'

# Conditional GET (304 on cached ETag)
ETAG=$(curl -sI https://api.algovoi.co.uk/.well-known/pay-skills.json | grep -i etag | awk '{print $2}' | tr -d '\r')
curl -sI -H "If-None-Match: $ETAG" https://api.algovoi.co.uk/.well-known/pay-skills.json | head -1
# → HTTP/1.1 304 Not Modified
```

The catalog also renders inside `pay skills probe` cleanly (provider entries match the schema imported via `pay_types::registry::ProviderFrontmatter`).

## xChain context (relevant for Solana + Stellar destinations on pay.sh)

AlgoVoi exposes a MetaMask payment path on every Algorand, Solana, and Stellar mainnet checkout. Customers holding USDC on any of seven supported EVM source chains (Base, Arbitrum, Polygon, Optimism, Ethereum, BNB Chain, Avalanche) can pay through pay.sh's CLI without ever installing a destination-chain wallet:

- **Solana** routes via Circle CCTP V2 Fast Transfer (~50s, native USDC).
- **Algorand** routes via Allbridge Core (Allbridge-wrapped USDCa, ASA `31566704`).
- **Stellar** routes via Allbridge Core's swap-and-bridge (canonical Circle USDC at issuer `GA5ZSEJ…`, any Stellar wallet works — no Soroban-aware wallet required).

CCTP V2 will be added to Stellar as a second protocol once Circle ships Stellar mainnet contracts publicly.

## Contact

- Operator: chopmob@gmail.com
- Catalog: https://api.algovoi.co.uk/.well-known/pay-skills.json
- A2A discovery: https://api.algovoi.co.uk/.well-known/agent-card.json
- Security policy: https://api.algovoi.co.uk/.well-known/security.txt
- Documentation: https://docs.algovoi.co.uk/concepts/xchain
