### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting Security Problems
+
+**DO NOT CREATE A GITHUB ISSUE** to report a security problem.
+
+Instead please use this [Report a Vulnerability](https://github.com/solana-foundation/pay/security/advisories/new) link.
+
+Provide a helpful title and detailed description of the problem.
+
+Expect a response as fast as possible in the advisory, typically within 72 hours.


### PR DESCRIPTION
Adds a `SECURITY.md` matching the policy used in [solana-foundation/kora](https://github.com/solana-foundation/kora/blob/main/SECURITY.md): vulnerabilities should be reported privately via the GitHub Security Advisory flow rather than as public issues.

This makes the "Report a Vulnerability" button visible on the repo's Security tab and gives external reporters a clear, private channel.