### PR TITLE
feat: add replay tools to payment debugger

### DIFF
--- a/pdb/api/correlation.ts
+++ b/pdb/api/correlation.ts
@@ -15,9 +15,11 @@ export interface LogEntry {
   ts: string;
   method: string;
   path: string;
+  url: string;
   status: number;
   ms: number;
   reqHeaders: Record<string, string>;
+  reqBody: string | null;
   resHeaders: Record<string, string>;
   resBody: string | null;
   clientIp: string;
@@ -146,7 +148,11 @@ export class FlowCorrelation {
     const flow: PaymentFlow = {
       id,
       protocol,
-      resource: entry.path,
+      resource: entry.url,
+      requestMethod: entry.method,
+      requestUrl: entry.url,
+      requestHeaders: entry.reqHeaders,
+      requestBody: entry.reqBody,
       status: "payment-required",
       clientIp: entry.clientIp,
       startedAt: now,
@@ -164,11 +170,14 @@ export class FlowCorrelation {
           message: `402 Payment Required`,
           detail:
             protocol === "mpp"
-              ? `www-authenticate: ${truncate(resHeader(entry, "www-authenticate"), 120)}`
-              : `x-payment-required: ${truncate(resHeader(entry, "x-payment-required"), 120)}`,
+              ? formatHeaderDetail("www-authenticate", resHeader(entry, "www-authenticate"))
+              : formatHeaderDetail("x-payment-required", resHeader(entry, "x-payment-required")),
         },
       ],
       challengeHeaders: entry.resHeaders,
+      responseStatus: entry.status,
+      responseHeaders: entry.resHeaders,
+      responseBody: entry.resBody,
     };
 
     this.addFlow(flow);
@@ -183,7 +192,7 @@ export class FlowCorrelation {
     if (!flow || flow.status !== "payment-required") {
       // Path-only fallback: find most recent pending flow for this path
       flow = [...this.flows].reverse().find(
-        (f) => f.resource === entry.path && f.status === "payment-required"
+        (f) => pathFromUrl(f.requestUrl) === entry.path && f.status === "payment-required"
       ) ?? null;
     }
 
@@ -209,8 +218,12 @@ export class FlowCorrelation {
 
     // Update flow
     flow.paymentHeaders = entry.reqHeaders;
+    flow.responseStatus = entry.status;
     flow.responseHeaders = entry.resHeaders;
     flow.responseBody = entry.resBody;
+    if (!flow.requestBody && entry.reqBody) {
+      flow.requestBody = entry.reqBody;
+    }
     flow.updatedAt = now;
     flow.durationMs =
       new Date(now).getTime() - new Date(flow.startedAt).getTime();
@@ -222,8 +235,8 @@ export class FlowCorrelation {
         message: `Payment accepted`,
         detail:
           protocol === "mpp"
-            ? `payment-receipt: ${truncate(resHeader(entry, "payment-receipt"), 120)}`
-            : `x-payment-response verified`,
+            ? formatHeaderDetail("payment-receipt", resHeader(entry, "payment-receipt"))
+            : formatHeaderDetail("x-payment-response", "verified"),
       });
       flow.events.push({
         ts: now,
@@ -289,7 +302,11 @@ export class FlowCorrelation {
     const flow: PaymentFlow = {
       id,
       protocol,
-      resource: entry.path,
+      resource: entry.url,
+      requestMethod: entry.method,
+      requestUrl: entry.url,
+      requestHeaders: entry.reqHeaders,
+      requestBody: entry.reqBody,
       status: "resource-delivered",
       clientIp: entry.clientIp,
       startedAt: now,
@@ -303,6 +320,7 @@ export class FlowCorrelation {
           detail: "Payment flow completed (challenge not captured)",
         },
       ],
+      responseStatus: entry.status,
       responseHeaders: entry.resHeaders,
       responseBody: entry.resBody,
     };
@@ -335,9 +353,9 @@ export class FlowCorrelation {
     this.flows.push(flow);
     if (this.flows.length > MAX_FLOWS) {
       const removed = this.flows.shift()!;
-      this.flowIndex.delete(flowKey(removed.clientIp, removed.resource));
+      this.flowIndex.delete(flowKey(removed.clientIp, pathFromUrl(removed.requestUrl)));
     }
-    this.flowIndex.set(flowKey(flow.clientIp, flow.resource), flow);
+    this.flowIndex.set(flowKey(flow.clientIp, pathFromUrl(flow.requestUrl)), flow);
   }
 
   private emit(msg: SSEMessage): void {
@@ -414,4 +432,30 @@ function resHeader(entry: LogEntry, key: string): string {
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+function formatHeaderDetail(name: string, value: string): string {
+  return `${name}: ${truncate(redactHeaderValue(name, value), 120)}`;
+}
+
+function redactHeaderValue(name: string, value: string): string {
+  switch (name.toLowerCase()) {
+    case "authorization":
+    case "www-authenticate":
+    case "payment-receipt":
+    case "x-payment":
+    case "x-payment-response":
+    case "x-payment-required":
+      return "[REDACTED]";
+    default:
+      return value;
+  }
+}
+
+function pathFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
 }

--- a/pdb/api/index.ts
+++ b/pdb/api/index.ts
@@ -122,6 +122,7 @@ async function createApp() {
     if (req.path === "/" || req.path.startsWith("/__402/pdb"))
       return next();
     const start = Date.now();
+    const requestUrl = `${req.protocol}://${req.get("host") || "localhost"}${req.originalUrl}`;
 
     const chunks: Buffer[] = [];
     let writeHeadHeaders: Record<string, string> = {};
@@ -152,6 +153,7 @@ async function createApp() {
       for (const [k, v] of Object.entries(req.headers)) {
         if (typeof v === "string") reqHeaders[k] = v;
       }
+      const reqBody = serializeRequestBody(req.method, req.body);
       const resHeaders: Record<string, string> = { ...writeHeadHeaders };
       for (const [k, v] of Object.entries(res.getHeaders())) {
         if (v != null) resHeaders[k] = String(v);
@@ -171,9 +173,11 @@ async function createApp() {
         ts: new Date().toISOString(),
         method: req.method,
         path: req.path,
+        url: requestUrl,
         status: res.statusCode,
         ms: Date.now() - start,
         reqHeaders,
+        reqBody,
         resHeaders,
         resBody,
         clientIp,
@@ -566,6 +570,23 @@ function toWebRequest(req: express.Request): globalThis.Request {
       ? undefined
       : JSON.stringify(req.body),
   });
+}
+
+function serializeRequestBody(method: string, body: unknown): string | null {
+  if (method === "GET" || method === "HEAD" || body == null) {
+    return null;
+  }
+
+  if (typeof body === "string") {
+    return body.length > 4096 ? `${body.slice(0, 4096)}…` : body;
+  }
+
+  try {
+    const serialized = JSON.stringify(body);
+    return serialized.length > 4096 ? `${serialized.slice(0, 4096)}…` : serialized;
+  } catch {
+    return null;
+  }
 }
 
 // ── Local dev server ──

--- a/pdb/api/types.ts
+++ b/pdb/api/types.ts
@@ -33,6 +33,10 @@ export interface PaymentFlow {
   id: string; // "flow-1", "flow-2", …
   protocol: Protocol;
   resource: string; // URL path, e.g. "/mpp/quote/GOOG"
+  requestMethod: string;
+  requestUrl: string;
+  requestHeaders?: Record<string, string>;
+  requestBody?: string | null;
   status: FlowStatus;
   clientIp: string;
   startedAt: string; // ISO
@@ -45,6 +49,7 @@ export interface PaymentFlow {
   // Raw data for detail inspection
   challengeHeaders?: Record<string, string>;
   paymentHeaders?: Record<string, string>;
+  responseStatus?: number;
   responseHeaders?: Record<string, string>;
   responseBody?: string | null;
 }

--- a/pdb/src/App.css
+++ b/pdb/src/App.css
@@ -369,12 +369,16 @@ body {
   background: var(--bg-raised);
   display: grid;
   grid-template-columns: 220px 1fr 1fr;
+  height: clamp(220px, 48vh, 500px);
   min-height: 220px;
-  max-height: 500px;
   overflow: hidden;
   animation: slideDown 0.15s ease;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.flow-detail > * {
+  min-height: 0;
 }
 
 /* ── Sequence Diagram ── */
@@ -454,10 +458,16 @@ body {
 /* ── Detail Panel (tabs + content) ── */
 
 .detail-panel {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
   min-height: 0;
+  border-right: 1px solid var(--border);
+}
+
+.detail-content {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .detail-tabs {
@@ -492,6 +502,118 @@ body {
   border-bottom-color: var(--accent);
 }
 
+.replay-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.replay-card {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.replay-header h3,
+.raw-http-header h3 {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.replay-header p,
+.raw-http-header span,
+.replay-note {
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.replay-actions {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-top: 14px;
+  min-width: 0;
+}
+
+.replay-button {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  flex: 1 1 0;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.replay-button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.replay-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.replay-button.copied {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.replay-note {
+  margin-top: 10px;
+}
+
+.replay-panel .splits {
+  border-right: none;
+  padding-top: 14px;
+}
+
+.raw-http-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  padding: 16px 20px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  overscroll-behavior: contain;
+}
+
+.raw-http-header {
+  flex-shrink: 0;
+  margin-bottom: 12px;
+}
+
+.raw-http-pre {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  min-height: 0;
+  overflow-x: auto;
+  overflow-y: visible;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* ── Payment Splits ── */
 
 .splits {
@@ -499,7 +621,6 @@ body {
   overflow-y: auto;
   min-height: 0;
   flex: 1;
-  border-right: 1px solid var(--border);
 }
 
 .splits h3 {

--- a/pdb/src/components/FlowDetail.tsx
+++ b/pdb/src/components/FlowDetail.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import type { PaymentFlow } from "../types";
 import { SequenceDiagram } from "./SequenceDiagram";
 import { EventLog } from "./EventLog";
-import { PaymentSplits } from "./PaymentSplits";
+import { ReplayPanel } from "./ReplayPanel";
+import { RawHttpPanel } from "./RawHttpPanel";
 
 interface Props {
   flow: PaymentFlow;
@@ -9,10 +11,41 @@ interface Props {
 
 export function FlowDetail({ flow }: Props) {
   const success = flow.status === "resource-delivered";
+  const [tab, setTab] = useState<"replay" | "request" | "response">("replay");
+
   return (
     <div className="flow-detail">
       <SequenceDiagram steps={flow.steps} failed={flow.status === "failed"} success={success} />
-      <PaymentSplits flow={flow} success={success} />
+      <div className="detail-panel">
+        <div className="detail-tabs">
+          <button
+            className={`detail-tab${tab === "replay" ? " active" : ""}`}
+            onClick={() => setTab("replay")}
+            type="button"
+          >
+            Replay
+          </button>
+          <button
+            className={`detail-tab${tab === "request" ? " active" : ""}`}
+            onClick={() => setTab("request")}
+            type="button"
+          >
+            Request
+          </button>
+          <button
+            className={`detail-tab${tab === "response" ? " active" : ""}`}
+            onClick={() => setTab("response")}
+            type="button"
+          >
+            Response
+          </button>
+        </div>
+        <div className="detail-content">
+          {tab === "replay" && <ReplayPanel flow={flow} success={success} />}
+          {tab === "request" && <RawHttpPanel flow={flow} mode="request" />}
+          {tab === "response" && <RawHttpPanel flow={flow} mode="response" />}
+        </div>
+      </div>
       <EventLog events={flow.events} />
     </div>
   );

--- a/pdb/src/components/RawHttpPanel.tsx
+++ b/pdb/src/components/RawHttpPanel.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import type { PaymentFlow } from "../types";
+import { buildRawRequest, buildRawResponse } from "../utils/httpReplay";
+
+interface Props {
+  flow: PaymentFlow;
+  mode: "request" | "response";
+}
+
+export function RawHttpPanel({ flow, mode }: Props) {
+  const content = useMemo(
+    () => (mode === "request" ? buildRawRequest(flow) : buildRawResponse(flow)),
+    [flow, mode],
+  );
+
+  return (
+    <div className="raw-http-panel">
+      <div className="raw-http-header">
+        <h3>{mode === "request" ? "Raw Request" : "Raw Response"}</h3>
+        <span>Payment headers are redacted automatically.</span>
+      </div>
+      <pre className="raw-http-pre">{content}</pre>
+    </div>
+  );
+}

--- a/pdb/src/components/ReplayPanel.tsx
+++ b/pdb/src/components/ReplayPanel.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from "react";
+import type { PaymentFlow } from "../types";
+import {
+  buildReplayCommand,
+  replaySupportMessage,
+} from "../utils/httpReplay";
+import { PaymentSplits } from "./PaymentSplits";
+
+interface Props {
+  flow: PaymentFlow;
+  success: boolean;
+}
+
+export function ReplayPanel({ flow, success }: Props) {
+  const [copiedKind, setCopiedKind] = useState<string | null>(null);
+  const curlCommand = useMemo(() => buildReplayCommand(flow, "curl"), [flow]);
+  const httpieCommand = useMemo(() => buildReplayCommand(flow, "httpie"), [flow]);
+  const payFetchCommand = useMemo(() => buildReplayCommand(flow, "pay-fetch"), [flow]);
+  const payFetchNote = replaySupportMessage(flow);
+
+  async function copyCommand(kind: string, command: string | null) {
+    if (!command) return;
+    await copyToClipboard(command);
+    setCopiedKind(kind);
+    window.setTimeout(() => setCopiedKind((current) => (current === kind ? null : current)), 1600);
+  }
+
+  return (
+    <div className="replay-panel">
+      <div className="replay-card">
+        <div className="replay-header">
+          <div>
+            <h3>Replay</h3>
+            <p>Re-run this request in your terminal with redacted payment headers.</p>
+          </div>
+        </div>
+        <div className="replay-actions">
+          <CopyButton
+            label="Copy as curl"
+            copied={copiedKind === "curl"}
+            onClick={() => copyCommand("curl", curlCommand)}
+          />
+          <CopyButton
+            label="Copy as HTTPie"
+            copied={copiedKind === "httpie"}
+            onClick={() => copyCommand("httpie", httpieCommand)}
+          />
+          <CopyButton
+            label="Copy as pay fetch"
+            copied={copiedKind === "pay-fetch"}
+            disabled={!payFetchCommand}
+            title={payFetchNote ?? undefined}
+            onClick={() => copyCommand("pay-fetch", payFetchCommand)}
+          />
+        </div>
+        {payFetchNote && <div className="replay-note">{payFetchNote}</div>}
+      </div>
+      <PaymentSplits flow={flow} success={success} />
+    </div>
+  );
+}
+
+function CopyButton({
+  copied,
+  disabled,
+  label,
+  title,
+  onClick,
+}: {
+  copied: boolean;
+  disabled?: boolean;
+  label: string;
+  title?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={`replay-button${copied ? " copied" : ""}`}
+      disabled={disabled}
+      onClick={onClick}
+      title={title}
+      type="button"
+    >
+      {copied ? "Copied" : label}
+    </button>
+  );
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "absolute";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}

--- a/pdb/src/utils/httpReplay.ts
+++ b/pdb/src/utils/httpReplay.ts
@@ -1,0 +1,188 @@
+import type { PaymentFlow } from "../types";
+
+type ReplayKind = "curl" | "httpie" | "pay-fetch";
+
+const REDACTED = "[REDACTED]";
+const REDACTED_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "www-authenticate",
+  "payment-receipt",
+  "x-payment",
+  "x-payment-response",
+  "x-payment-required",
+  "cookie",
+  "set-cookie",
+]);
+
+const OMITTED_REPLAY_HEADERS = new Set([
+  "accept-encoding",
+  "connection",
+  "content-length",
+  "host",
+  "origin",
+  "referer",
+  "user-agent",
+]);
+
+export function redactHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!headers) return {};
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      REDACTED_HEADERS.has(name.toLowerCase()) ? REDACTED : value,
+    ]),
+  );
+}
+
+export function buildRawRequest(flow: PaymentFlow): string {
+  const lines = [`${flow.requestMethod} ${flow.requestUrl} HTTP/1.1`];
+  const headers = redactHeaders(flow.requestHeaders);
+
+  for (const [name, value] of Object.entries(headers)) {
+    lines.push(`${name}: ${value}`);
+  }
+
+  if (flow.requestBody) {
+    lines.push("", prettyBody(flow.requestBody));
+  }
+
+  return lines.join("\n");
+}
+
+export function buildRawResponse(flow: PaymentFlow): string {
+  const lines = [
+    `HTTP/1.1 ${flow.responseStatus ?? 0}`,
+  ];
+  const headers = redactHeaders(flow.responseHeaders);
+
+  for (const [name, value] of Object.entries(headers)) {
+    lines.push(`${name}: ${value}`);
+  }
+
+  if (flow.responseBody) {
+    lines.push("", prettyBody(flow.responseBody));
+  }
+
+  return lines.join("\n");
+}
+
+export function buildReplayCommand(
+  flow: PaymentFlow,
+  kind: ReplayKind,
+): string | null {
+  const headers = replayHeaders(flow.requestHeaders);
+  const body = normalizedBody(flow.requestBody);
+
+  switch (kind) {
+    case "curl":
+      return buildCurlCommand(flow, headers, body);
+    case "httpie":
+      return buildHttpieCommand(flow, headers, body);
+    case "pay-fetch":
+      if (flow.requestMethod !== "GET" || body) {
+        return null;
+      }
+      return buildPayFetchCommand(flow, headers);
+    default:
+      return null;
+  }
+}
+
+export function replaySupportMessage(flow: PaymentFlow): string | null {
+  if (flow.requestMethod !== "GET" || normalizedBody(flow.requestBody)) {
+    return "`pay fetch` replay currently supports GET requests without a body.";
+  }
+
+  return null;
+}
+
+function buildCurlCommand(
+  flow: PaymentFlow,
+  headers: Array<[string, string]>,
+  body: string | null,
+): string {
+  const parts = ["curl", "-X", shellQuote(flow.requestMethod), shellQuote(flow.requestUrl)];
+
+  for (const [name, value] of headers) {
+    parts.push("-H", shellQuote(`${name}: ${value}`));
+  }
+
+  if (body) {
+    parts.push("--data", shellQuote(compactBody(body)));
+  }
+
+  return joinCommand(parts);
+}
+
+function buildHttpieCommand(
+  flow: PaymentFlow,
+  headers: Array<[string, string]>,
+  body: string | null,
+): string {
+  const parts = ["http", shellQuote(flow.requestMethod), shellQuote(flow.requestUrl)];
+
+  for (const [name, value] of headers) {
+    parts.push(shellQuote(`${name}:${value}`));
+  }
+
+  if (body) {
+    parts.push("--raw", shellQuote(compactBody(body)));
+  }
+
+  return joinCommand(parts);
+}
+
+function buildPayFetchCommand(
+  flow: PaymentFlow,
+  headers: Array<[string, string]>,
+): string {
+  const parts = ["pay", "fetch", shellQuote(flow.requestUrl)];
+
+  for (const [name, value] of headers) {
+    parts.push("-H", shellQuote(`${name}: ${value}`));
+  }
+
+  return joinCommand(parts);
+}
+
+function joinCommand(parts: string[]): string {
+  return parts.join(" ");
+}
+
+function replayHeaders(
+  headers: Record<string, string> | undefined,
+): Array<[string, string]> {
+  return Object.entries(redactHeaders(headers))
+    .filter(([name]) => !OMITTED_REPLAY_HEADERS.has(name.toLowerCase()))
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+function normalizedBody(body: string | null | undefined): string | null {
+  if (!body) return null;
+  const trimmed = body.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function prettyBody(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+function compactBody(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body));
+  } catch {
+    return body;
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
Summary
add replay tooling to the Payment Debugger with copy actions for curl, HTTPie, and pay fetch
add raw Request and Response tabs for inspecting captured HTTP traffic
redact payment-sensitive headers in replay output and raw views
