### PR TITLE
Fix Solana Pay license links

### DIFF
--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -225,6 +225,6 @@ A Solana Pay transfer request URL describes a non-interactive request for a SOL 
 
 ## License
 
-The Solana Pay JavaScript SDK is open source and available under the MIT License. See the [LICENSE](../../../../LICENSE) file for more info.
+The Solana Pay JavaScript SDK is open source and available under the MIT License. See the [LICENSE](https://github.com/solana-foundation/pay/blob/main/LICENSE) file for more info.
 
 Subject to the foregoing, the Terms of Service available at solana.com/tos

--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -225,6 +225,6 @@ A Solana Pay transfer request URL describes a non-interactive request for a SOL 
 
 ## License
 
-The Solana Pay JavaScript SDK is open source and available under the MIT License. See the [LICENSE](./LICENSE) file for more info.
+The Solana Pay JavaScript SDK is open source and available under the MIT License. See the [LICENSE](../../../../LICENSE) file for more info.
 
 Subject to the foregoing, the Terms of Service available at solana.com/tos

--- a/typescript/packages/solana-pay/docs/src/INTRODUCTION.md
+++ b/typescript/packages/solana-pay/docs/src/INTRODUCTION.md
@@ -41,6 +41,6 @@ Have an idea? Feel free to open an [issue](https://github.com/solana-foundation/
 
 ## License
 
-Solana Pay is open source and available under the MIT License. See the [LICENSE](./LICENSE) file for more info.
+Solana Pay is open source and available under the MIT License. See the [LICENSE](../../../../../LICENSE) file for more info.
 
 ![Solana Pay](./images/solana-pay.png)

--- a/typescript/packages/solana-pay/examples/point-of-sale/README.md
+++ b/typescript/packages/solana-pay/examples/point-of-sale/README.md
@@ -178,7 +178,7 @@ https://<YOUR DEPLOYMENT URL>?recipient=<YOUR WALLET ADDRESS>&label=Your+Store+N
 
 ## License
 
-The Solana Pay Point of Sale app is open source and available under the MIT License. See the [LICENSE](./LICENSE) file for more info.
+The Solana Pay Point of Sale app is open source and available under the MIT License. See the [LICENSE](../../../../../LICENSE) file for more info.
 
 <!-- Links -->
 


### PR DESCRIPTION
## Summary
- update nested Solana Pay README/docs license links to point to the repository root LICENSE file

## Verification
- checked local Markdown links in the changed files
- git diff --check