### PR TITLE
feat: add local spending policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ When a command, Claude Code, Codex, or another MCP client hits a paid endpoint, 
 pay setup    # Touch ID on macOS, Windows Hello on Windows, GNOME Keyring on Linux, or choose 1Password
 ```
 
+### 🛡️ Spending Policies
+
+For agent flows where Touch ID per call isn't practical, `pay` enforces a named spending policy locally before signing. A policy is a per-tx cap, a daily cap, an optional recipient/origin allowlist, an expiry, and a kill switch — all checked before any keystore access. If a request fails the policy, no signature is produced and nothing leaves your machine.
+
+```sh
+pay policy create work \
+    --max-per-tx 0.10 \
+    --daily-cap 1.00 \
+    --allow api.example.com \
+    --default
+
+pay policy status                 # remaining daily budget
+pay policy pause                  # one-command kill switch
+pay --policy work claude          # apply per invocation, or use --default
+```
+
+Policies live at `~/.config/pay/policies.toml` and can be bound to specific accounts. They compose with biometrics — both gates run; the stricter one wins.
+
 ### 📚 Open Source Catalog
 
 The paid API catalog is open source in the [`pay-skills`](https://github.com/solana-foundation/pay-skills) repo.
@@ -115,7 +133,10 @@ pay whoami
 # 2. Make a paid gated API call to https://debugger.pay.sh sandbox endpoints
 pay --sandbox curl https://debugger.pay.sh/mpp/quote/AAPL
 
-# 3. Or let your AI agent handle it
+# 3. (Optional) Cap what an agent can spend
+pay policy create agent --max-per-tx 0.10 --daily-cap 1.00 --default
+
+# 4. Let your AI agent handle paid calls within the policy
 pay claude
 ```
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,7 +39,7 @@ owo-colors = "4"
 dialoguer = "0.12"
 
 # Time
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 
 # MCP
 rmcp = { version = "0.9", features = ["server", "transport-io"] }

--- a/rust/crates/cli/src/commands/account/destroy.rs
+++ b/rust/crates/cli/src/commands/account/destroy.rs
@@ -248,6 +248,7 @@ fn discover_legacy_account(name: &str) -> Option<Account> {
                 path: None,
                 secret_key_b58: None,
                 created_at: None,
+                policy: None,
             });
         }
     }
@@ -267,6 +268,7 @@ fn discover_legacy_account(name: &str) -> Option<Account> {
                 path: None,
                 secret_key_b58: None,
                 created_at: None,
+                policy: None,
             });
         }
     }
@@ -285,6 +287,7 @@ fn discover_legacy_account(name: &str) -> Option<Account> {
                 path: None,
                 secret_key_b58: None,
                 created_at: None,
+                policy: None,
             });
         }
     }

--- a/rust/crates/cli/src/commands/account/import.rs
+++ b/rust/crates/cli/src/commands/account/import.rs
@@ -108,6 +108,7 @@ impl ImportCommand {
                 account: None,
                 secret_key_b58: None,
                 created_at: None,
+                policy: None,
             },
         );
 

--- a/rust/crates/cli/src/commands/account/new.rs
+++ b/rust/crates/cli/src/commands/account/new.rs
@@ -364,6 +364,7 @@ pub fn save_account(
             path,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         },
     );
     accounts.save()

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod curl;
 pub mod fetch;
 pub mod help;
 pub mod http;
+pub mod policy;
 pub mod send;
 pub mod server;
 pub mod setup;
@@ -76,6 +77,12 @@ pub enum Command {
     /// Add a provider source (shorthand for `skills add`).
     #[command(alias = "add", short_flag = 'i')]
     Install(skills::install::InstallCommand),
+    /// Manage local spending policies that gate paid HTTP calls.
+    #[command(alias = "policies")]
+    Policy {
+        #[command(subcommand)]
+        command: Option<policy::PolicyCommand>,
+    },
     /// Start the MCP server (for Claude Code, Cursor, etc.)
     Mcp,
 }
@@ -125,6 +132,7 @@ impl Command {
             | Command::Skills { .. }
             | Command::Catalog { .. }
             | Command::Install(_)
+            | Command::Policy { .. }
             | Command::Server { .. }
             | Command::Mcp => false,
         }
@@ -145,6 +153,7 @@ impl Command {
             | Command::Skills { .. }
             | Command::Catalog { .. }
             | Command::Install(_)
+            | Command::Policy { .. }
             | Command::Send(_)
             | Command::Setup(_)
             | Command::Topup(_)
@@ -172,6 +181,7 @@ impl Command {
         keypair_override: Option<&str>,
         network_override: Option<&str>,
         account_override: Option<&str>,
+        policy_override: Option<&str>,
         verbose: bool,
         sandbox: bool,
     ) -> pay_core::Result<()> {
@@ -183,6 +193,10 @@ impl Command {
             Command::Account { command } => match command {
                 Some(cmd) => return cmd.run(),
                 None => return account::run_default(),
+            },
+            Command::Policy { command } => match command {
+                Some(cmd) => return cmd.run(),
+                None => return policy::run_default(),
             },
             Command::Whoami(cmd) => return cmd.run(network_override, account_override),
             Command::Skills { command } => return command.run(),
@@ -228,6 +242,7 @@ impl Command {
                     Some(parsed_headers),
                     network_override,
                     account_override,
+                    policy_override,
                     sandbox,
                     verbose,
                 );
@@ -244,6 +259,7 @@ impl Command {
             None,
             network_override,
             account_override,
+            policy_override,
             sandbox,
             verbose,
         )
@@ -260,6 +276,7 @@ fn handle_outcome(
     fetch_headers: Option<Vec<(String, String)>>,
     network_override: Option<&str>,
     account_override: Option<&str>,
+    policy_override: Option<&str>,
     sandbox: bool,
     verbose: bool,
 ) -> pay_core::Result<()> {
@@ -308,6 +325,7 @@ fn handle_outcome(
                         fetch_headers,
                         network_override,
                         account_override,
+                        policy_override,
                         verbose,
                     },
                 );
@@ -428,6 +446,7 @@ fn handle_outcome(
                         fetch_headers,
                         network_override,
                         account_override,
+                        policy_override,
                         verbose,
                     },
                 );
@@ -475,6 +494,7 @@ fn handle_outcome(
                         fetch_headers,
                         network_override,
                         account_override,
+                        policy_override,
                         verbose,
                     },
                 );
@@ -714,7 +734,36 @@ struct PaymentRetryContext<'a, 'tool> {
     fetch_headers: Option<Vec<(String, String)>>,
     network_override: Option<&'a str>,
     account_override: Option<&'a str>,
+    policy_override: Option<&'a str>,
     verbose: bool,
+}
+
+/// Resolve which policy applies for the current invocation.
+///
+/// Returns `None` if no policy is configured anywhere, or `Some(Policy)`
+/// otherwise. Errors only when the user explicitly named a policy that
+/// doesn't exist.
+fn resolve_policy_for_invocation(
+    cli_override: Option<&str>,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+) -> pay_core::Result<Option<pay_core::policy::Policy>> {
+    let policy_store = pay_core::policy::FilePolicyStore::default_path();
+    let policies = pay_core::policy::PolicyStore::load_policies(&policy_store)?;
+
+    // Look up the per-account binding when we know which account is in use.
+    let account_policy = if let Some(net) = network_override {
+        let file = pay_core::accounts::AccountsFile::load().unwrap_or_default();
+        let acct_opt = match account_override {
+            Some(name) => file.named_account_for_network(net, name).cloned(),
+            None => file.account_for_network(net).map(|(_, a)| a.clone()),
+        };
+        acct_opt.and_then(|a| a.policy)
+    } else {
+        None
+    };
+
+    pay_core::policy::resolve_active_policy(cli_override, account_policy.as_deref(), &policies)
 }
 
 fn pay_mpp_and_retry(
@@ -749,12 +798,36 @@ fn pay_mpp_and_retry(
              Drop `--network` or check `pay account list` for accounts on the offered networks."
         ))
     })?;
+
+    // Resolve the active policy (CLI flag → account binding → default).
+    let resolved_policy = resolve_policy_for_invocation(
+        ctx.policy_override,
+        ctx.network_override,
+        ctx.account_override,
+    )?;
+    let policy_store = pay_core::policy::FilePolicyStore::default_path();
+    let policy_ctx = resolved_policy.as_ref().map(|p| pay_core::policy::PolicyContext {
+        policy: p.clone(),
+        store: &policy_store,
+    });
+
+    // Capture the amount before signing so we can record the spend after a
+    // successful retry. Decoding the challenge can fail; if it does, we
+    // record nothing (better to under-count than to crash post-payment).
+    let amount_for_record: Option<u64> = if policy_ctx.is_some() {
+        let req: ChargeRequest = challenge.request.decode().ok().unwrap_or_default();
+        pay_core::policy::parse_amount_micro_usdc(&req.amount, &req.currency).ok()
+    } else {
+        None
+    };
+
     let (auth_header, ephemeral_notice) = mpp::build_credential(
         challenge,
         &store,
         ctx.network_override,
         ctx.account_override,
         Some(resource_url),
+        policy_ctx.as_ref(),
     )?;
 
     if let Some(resolved) = ephemeral_notice {
@@ -767,6 +840,19 @@ fn pay_mpp_and_retry(
 
     let retry_outcome =
         retry_with_header(ctx.tool, "Authorization", &auth_header, ctx.fetch_headers)?;
+
+    // Record the spend ONLY when the retry will exit cleanly. `RunOutcome::Completed`
+    // with a 2xx exit_code is the success signal — anything else means the
+    // payment didn't actually succeed and the daily counter shouldn't move.
+    let succeeded = matches!(
+        &retry_outcome,
+        RunOutcome::Completed { exit_code, .. } if *exit_code == 0
+    );
+    if succeeded
+        && let (Some(ctx), Some(amt)) = (&policy_ctx, amount_for_record)
+    {
+        pay_core::policy::record_payment_with_store(ctx, amt, chrono::Utc::now())?;
+    }
     handle_retry_outcome(retry_outcome, is_json)
 }
 
@@ -836,12 +922,34 @@ fn pay_x402_and_retry(
     }
 
     let store = pay_core::accounts::FileAccountsStore::default_path();
+
+    let resolved_policy = resolve_policy_for_invocation(
+        ctx.policy_override,
+        ctx.network_override,
+        ctx.account_override,
+    )?;
+    let policy_store = pay_core::policy::FilePolicyStore::default_path();
+    let policy_ctx = resolved_policy.as_ref().map(|p| pay_core::policy::PolicyContext {
+        policy: p.clone(),
+        store: &policy_store,
+    });
+    let amount_for_record: Option<u64> = if policy_ctx.is_some() {
+        pay_core::policy::parse_amount_micro_usdc(
+            &challenge.requirements.amount,
+            &challenge.requirements.currency,
+        )
+        .ok()
+    } else {
+        None
+    };
+
     let built_payment = x402::build_payment(
         challenge,
         &store,
         ctx.network_override,
         ctx.account_override,
         Some(resource_url),
+        policy_ctx.as_ref(),
     )?;
 
     if let Some(resolved) = built_payment.ephemeral_notice {
@@ -853,6 +961,16 @@ fn pay_x402_and_retry(
     }
 
     let retry_outcome = retry_with_headers(ctx.tool, &built_payment.headers, ctx.fetch_headers)?;
+
+    let succeeded = matches!(
+        &retry_outcome,
+        RunOutcome::Completed { exit_code, .. } if *exit_code == 0
+    );
+    if succeeded
+        && let (Some(ctx), Some(amt)) = (&policy_ctx, amount_for_record)
+    {
+        pay_core::policy::record_payment_with_store(ctx, amt, chrono::Utc::now())?;
+    }
     handle_retry_outcome(retry_outcome, is_json)
 }
 
@@ -869,12 +987,14 @@ fn pay_x402_siwx_and_retry(
     }
 
     let store = pay_core::accounts::FileAccountsStore::default_path();
+    // SIWX is sign-in only — no on-chain payment, so no policy gate / record.
     let built_payment = x402::build_siwx_auth_header(
         challenge,
         &store,
         ctx.network_override,
         ctx.account_override,
         Some(resource_url),
+        None,
     )?;
 
     if let Some(resolved) = built_payment.ephemeral_notice {

--- a/rust/crates/cli/src/commands/policy/create.rs
+++ b/rust/crates/cli/src/commands/policy/create.rs
@@ -1,0 +1,163 @@
+//! `pay policy create <name>` — create a new spending policy.
+
+use chrono::{DateTime, Utc};
+use owo_colors::OwoColorize;
+use pay_core::policy::{PoliciesFile, Policy, PolicyStore};
+
+use super::{AllowKind, classify_allow_value, parse_usd_to_micro};
+
+#[derive(clap::Args)]
+pub struct CreateCommand {
+    /// Name of the policy (referenced via `--policy <name>`).
+    pub name: String,
+
+    /// Per-transaction cap in USD (e.g. `0.10` or `$0.10`).
+    #[arg(long, value_name = "USD")]
+    pub max_per_tx: String,
+
+    /// Daily total cap in USD (e.g. `1.00`).
+    #[arg(long, value_name = "USD")]
+    pub daily_cap: String,
+
+    /// Allowed recipient pubkey OR request origin host. Repeatable. Auto-
+    /// detected: 32-byte base58 strings → recipient pubkey; everything else
+    /// → request origin host.
+    #[arg(long = "allow", value_name = "PUBKEY_OR_HOST", action = clap::ArgAction::Append)]
+    pub allow: Vec<String>,
+
+    /// Optional ISO-8601 expiry (e.g. `2026-12-31T23:59:59Z`). After this
+    /// timestamp every paid request rejects.
+    #[arg(long, value_name = "ISO8601")]
+    pub expires: Option<String>,
+
+    /// Replace an existing policy with the same name.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Set this policy as the default for future invocations.
+    #[arg(long = "default")]
+    pub set_default: bool,
+}
+
+impl CreateCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let max_per_tx = parse_usd_to_micro(&self.max_per_tx)?;
+        let daily_cap = parse_usd_to_micro(&self.daily_cap)?;
+        if max_per_tx == 0 {
+            return Err(pay_core::Error::Config(
+                "--max-per-tx must be greater than 0".to_string(),
+            ));
+        }
+        if daily_cap < max_per_tx {
+            return Err(pay_core::Error::Config(format!(
+                "--daily-cap ({}) must be >= --max-per-tx ({})",
+                self.daily_cap, self.max_per_tx
+            )));
+        }
+
+        let expires_at = match self.expires {
+            Some(ref s) => Some(parse_iso8601(s)?),
+            None => None,
+        };
+
+        let mut allowed_recipients = Vec::new();
+        let mut allowed_origins = Vec::new();
+        for raw in &self.allow {
+            match classify_allow_value(raw) {
+                AllowKind::Recipient(p) => allowed_recipients.push(p),
+                AllowKind::Origin(h) if h.is_empty() => {
+                    return Err(pay_core::Error::Config(
+                        "--allow cannot be empty".to_string(),
+                    ));
+                }
+                AllowKind::Origin(h) => allowed_origins.push(h),
+            }
+        }
+
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file: PoliciesFile = PolicyStore::load_policies(&store)?;
+        if file.get(&self.name).is_some() && !self.force {
+            return Err(pay_core::Error::Config(format!(
+                "policy `{}` already exists — use --force to overwrite",
+                self.name
+            )));
+        }
+
+        let policy = Policy {
+            name: self.name.clone(),
+            max_per_tx,
+            daily_cap,
+            allowed_recipients,
+            allowed_origins,
+            expires_at,
+            paused: false,
+            created_at: Utc::now(),
+        };
+        file.upsert(policy);
+        if self.set_default {
+            file.set_default(&self.name).ok_or_else(|| {
+                pay_core::Error::Config("default-policy mismatch after upsert".to_string())
+            })?;
+        }
+        PolicyStore::save_policies(&store, &file)?;
+
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Created policy `{}`", self.name),
+            &format!(
+                "Per-tx cap: {}\nDaily cap:  {}\n\nApply it with:\n  pay --policy {} curl …\n  pay policy use {}      # set as default\n  pay policy status {}   # see remaining budget",
+                super::format_usd(max_per_tx),
+                super::format_usd(daily_cap),
+                self.name,
+                self.name,
+                self.name,
+            ),
+        );
+        eprintln!();
+        eprintln!(
+            "{}",
+            "Note: spending policy is enforced by the pay CLI before signing. \
+             Touch ID still gates each spend if `auth_required: true` on the account."
+                .dimmed()
+        );
+        Ok(())
+    }
+}
+
+fn parse_iso8601(s: &str) -> pay_core::Result<DateTime<Utc>> {
+    // Accept either RFC 3339 with timezone or a bare date (interpreted as UTC midnight).
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        let naive = date
+            .and_hms_opt(23, 59, 59)
+            .ok_or_else(|| pay_core::Error::Config(format!("invalid date `{s}`")))?;
+        return Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc));
+    }
+    Err(pay_core::Error::Config(format!(
+        "--expires `{s}` is not a valid ISO 8601 timestamp or YYYY-MM-DD date"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso8601_accepts_rfc3339() {
+        let parsed = parse_iso8601("2026-12-31T23:59:59Z").unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-12-31T23:59:59+00:00");
+    }
+
+    #[test]
+    fn iso8601_accepts_bare_date_as_end_of_day() {
+        let parsed = parse_iso8601("2026-12-31").unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-12-31T23:59:59+00:00");
+    }
+
+    #[test]
+    fn iso8601_rejects_garbage() {
+        assert!(parse_iso8601("not-a-date").is_err());
+    }
+}

--- a/rust/crates/cli/src/commands/policy/delete.rs
+++ b/rust/crates/cli/src/commands/policy/delete.rs
@@ -1,0 +1,52 @@
+//! `pay policy delete <name>` — remove a policy and its tracked spend.
+
+use dialoguer::Confirm;
+use pay_core::policy::PolicyStore;
+
+#[derive(clap::Args)]
+pub struct DeleteCommand {
+    pub name: String,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, alias = "force")]
+    pub yes: bool,
+}
+
+impl DeleteCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file = PolicyStore::load_policies(&store)?;
+        if file.get(&self.name).is_none() {
+            return Err(pay_core::Error::Config(format!(
+                "policy `{}` not found",
+                self.name
+            )));
+        }
+
+        if !self.yes && std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+            let confirmed = Confirm::new()
+                .with_prompt(format!("Delete policy `{}`? This cannot be undone.", self.name))
+                .default(false)
+                .interact()
+                .map_err(|e| pay_core::Error::Config(format!("prompt error: {e}")))?;
+            if !confirmed {
+                eprintln!("Aborted.");
+                return Ok(());
+            }
+        }
+
+        file.remove(&self.name);
+        PolicyStore::save_policies(&store, &file)?;
+
+        let mut state = PolicyStore::load_state(&store)?;
+        state.forget(&self.name);
+        PolicyStore::save_state(&store, &state)?;
+
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Deleted policy `{}`", self.name),
+            "Tracked spend cleared.",
+        );
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/policy/list.rs
+++ b/rust/crates/cli/src/commands/policy/list.rs
@@ -1,0 +1,104 @@
+//! `pay policy list` — show all configured policies.
+
+use owo_colors::OwoColorize;
+use pay_core::policy::PolicyStore;
+
+use super::format_usd;
+
+#[derive(clap::Args)]
+pub struct ListCommand {
+    /// JSON output for scripting.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl ListCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let file = PolicyStore::load_policies(&store)?;
+        let state = PolicyStore::load_state(&store)?;
+
+        if file.policies.is_empty() {
+            if self.json || crate::no_dna::should_json(None) {
+                crate::output::print_json(&serde_json::json!({
+                    "policies": [],
+                    "default": null,
+                }))?;
+            } else {
+                eprintln!(
+                    "{}",
+                    "No policies configured. Create one with `pay policy create <name>`.".dimmed()
+                );
+            }
+            return Ok(());
+        }
+
+        if self.json || crate::no_dna::should_json(None) {
+            let policies: Vec<_> = file
+                .policies
+                .values()
+                .map(|p| {
+                    let spent = state
+                        .per_policy
+                        .get(&p.name)
+                        .map(|s| s.spent_today)
+                        .unwrap_or(0);
+                    serde_json::json!({
+                        "name": p.name,
+                        "paused": p.paused,
+                        "max_per_tx_micro": p.max_per_tx,
+                        "daily_cap_micro": p.daily_cap,
+                        "spent_today_micro": spent,
+                        "expires_at": p.expires_at,
+                        "allowed_recipients": p.allowed_recipients,
+                        "allowed_origins": p.allowed_origins,
+                    })
+                })
+                .collect();
+            crate::output::print_json(&serde_json::json!({
+                "policies": policies,
+                "default": file.default,
+            }))?;
+            return Ok(());
+        }
+
+        eprintln!(
+            "{:<24} {:<10} {:>10} {:>10} {:>10}",
+            "NAME".bold(),
+            "STATUS".bold(),
+            "PER-TX".bold(),
+            "DAILY".bold(),
+            "SPENT".bold(),
+        );
+        for policy in file.policies.values() {
+            let status = if policy.paused {
+                "paused".to_string()
+            } else if let Some(exp) = policy.expires_at
+                && exp <= chrono::Utc::now()
+            {
+                "expired".to_string()
+            } else {
+                "active".to_string()
+            };
+            let spent = state
+                .per_policy
+                .get(&policy.name)
+                .map(|s| s.spent_today)
+                .unwrap_or(0);
+            let default_marker = if file.default.as_deref() == Some(policy.name.as_str()) {
+                " (default)"
+            } else {
+                ""
+            };
+            eprintln!(
+                "{:<24} {:<10} {:>10} {:>10} {:>10}",
+                format!("{}{}", policy.name, default_marker),
+                status,
+                format_usd(policy.max_per_tx),
+                format_usd(policy.daily_cap),
+                format_usd(spent),
+            );
+        }
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/policy/mod.rs
+++ b/rust/crates/cli/src/commands/policy/mod.rs
@@ -1,0 +1,238 @@
+//! `pay policy` — manage spending policies enforced before paid HTTP calls.
+
+pub mod create;
+pub mod delete;
+pub mod list;
+pub mod pause;
+pub mod resume;
+pub mod status;
+pub mod update;
+pub mod use_cmd;
+
+use clap::Subcommand;
+use owo_colors::OwoColorize;
+
+#[derive(Subcommand)]
+pub enum PolicyCommand {
+    /// Create a new spending policy.
+    Create(create::CreateCommand),
+    /// List all configured policies.
+    #[command(alias = "ls")]
+    List(list::ListCommand),
+    /// Show policy rules + remaining daily budget.
+    Status(status::StatusCommand),
+    /// Pause a policy (every paid request rejects).
+    Pause(pause::PauseCommand),
+    /// Resume a paused policy.
+    Resume(resume::ResumeCommand),
+    /// Update an existing policy in place.
+    Update(update::UpdateCommand),
+    /// Delete a policy and clear its tracked spend.
+    #[command(alias = "rm")]
+    Delete(delete::DeleteCommand),
+    /// Set the default policy used when no `--policy` flag is passed.
+    Use(use_cmd::UseCommand),
+}
+
+impl PolicyCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        match self {
+            Self::Create(cmd) => cmd.run(),
+            Self::List(cmd) => cmd.run(),
+            Self::Status(cmd) => cmd.run(),
+            Self::Pause(cmd) => cmd.run(),
+            Self::Resume(cmd) => cmd.run(),
+            Self::Update(cmd) => cmd.run(),
+            Self::Delete(cmd) => cmd.run(),
+            Self::Use(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Default behaviour when `pay policy` is run without a subcommand: list
+/// policies and print the available subcommands so the user discovers them.
+pub fn run_default() -> pay_core::Result<()> {
+    list::ListCommand { json: false }.run()?;
+
+    eprintln!("{}", "Subcommands:".dimmed());
+    for (name, summary) in SUBCOMMAND_HELP {
+        eprintln!(
+            "{}",
+            format!("  pay policy {name:<10}  {summary}").dimmed()
+        );
+    }
+    Ok(())
+}
+
+const SUBCOMMAND_HELP: &[(&str, &str)] = &[
+    ("create", "Create a new policy"),
+    ("status", "Show rules + remaining daily budget"),
+    ("update", "Edit an existing policy"),
+    ("pause", "Pause a policy (kill switch)"),
+    ("resume", "Resume a paused policy"),
+    ("use", "Set the default policy"),
+    ("rm", "Delete a policy (alias: delete)"),
+];
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+/// Parse a USD amount string ("0.10", "1", "1.5") to micro-USDC.
+/// Mirrors `parse_decimal_micro_units` in `main.rs` so the CLI parses USD
+/// inputs identically across `--yolo-upto` and policy flags.
+pub(crate) fn parse_usd_to_micro(input: &str) -> pay_core::Result<u64> {
+    let trimmed = input.trim();
+    let without_symbol = trimmed.strip_prefix('$').unwrap_or(trimmed).trim();
+    let without_suffix = without_symbol
+        .strip_suffix("USDC")
+        .or_else(|| without_symbol.strip_suffix("usdc"))
+        .unwrap_or(without_symbol)
+        .trim();
+    parse_decimal_micro_units(without_suffix)
+        .map_err(|e| pay_core::Error::Config(format!("invalid amount `{input}`: {e}")))
+}
+
+fn parse_decimal_micro_units(input: &str) -> Result<u64, String> {
+    if input.is_empty() {
+        return Err("amount must not be empty".to_string());
+    }
+    if input.starts_with('-') {
+        return Err("amount must be positive".to_string());
+    }
+    let mut parts = input.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || whole.is_empty()
+        || !whole.bytes().all(|b| b.is_ascii_digit())
+        || !fraction.bytes().all(|b| b.is_ascii_digit())
+        || fraction.len() > 6
+    {
+        return Err("use a decimal amount with at most 6 decimal places".to_string());
+    }
+    let whole_units = whole
+        .parse::<u64>()
+        .map_err(|_| "amount is too large".to_string())?
+        .checked_mul(1_000_000)
+        .ok_or_else(|| "amount is too large".to_string())?;
+    let mut fraction_units = 0u64;
+    for (index, byte) in fraction.bytes().enumerate() {
+        let digit = (byte - b'0') as u64;
+        let place = 10_u64.pow(5 - index as u32);
+        fraction_units = fraction_units
+            .checked_add(digit * place)
+            .ok_or_else(|| "amount is too large".to_string())?;
+    }
+    whole_units
+        .checked_add(fraction_units)
+        .ok_or_else(|| "amount is too large".to_string())
+}
+
+/// Format a micro-USDC amount as a human-readable USD string.
+pub(crate) fn format_usd(micro: u64) -> String {
+    let whole = micro / 1_000_000;
+    let frac = micro % 1_000_000;
+    if frac == 0 {
+        format!("${whole}")
+    } else {
+        let mut frac_s = format!("{frac:06}");
+        while frac_s.ends_with('0') {
+            frac_s.pop();
+        }
+        format!("${whole}.{frac_s}")
+    }
+}
+
+/// Heuristically classify an `--allow <X>` value: looks like a base58 Solana
+/// pubkey ⇒ recipient; otherwise treat as a request-origin host.
+pub(crate) fn classify_allow_value(value: &str) -> AllowKind {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return AllowKind::Origin(String::new());
+    }
+    // Base58 Solana pubkeys decode to 32 bytes — exactly. Use length
+    // post-decode to avoid false positives like "abc".
+    if let Ok(bytes) = bs58::decode(trimmed).into_vec()
+        && bytes.len() == 32
+    {
+        return AllowKind::Recipient(trimmed.to_string());
+    }
+    AllowKind::Origin(trimmed.to_lowercase())
+}
+
+pub(crate) enum AllowKind {
+    Recipient(String),
+    Origin(String),
+}
+
+/// Open the file store, look up the named policy, error helpfully if missing.
+pub(crate) fn load_policy_or_error(
+    store: &pay_core::policy::FilePolicyStore,
+    name: &str,
+) -> pay_core::Result<(pay_core::policy::PoliciesFile, pay_core::policy::Policy)> {
+    let file = pay_core::policy::PolicyStore::load_policies(store)?;
+    let policy = file
+        .get(name)
+        .cloned()
+        .ok_or_else(|| pay_core::Error::Config(format!("policy `{name}` not found")))?;
+    Ok((file, policy))
+}
+
+/// Resolve the policy name a `[name]` arg refers to: explicit name → that;
+/// none → the configured default; both missing → error.
+pub(crate) fn resolve_target_name(
+    explicit: Option<&str>,
+    file: &pay_core::policy::PoliciesFile,
+) -> pay_core::Result<String> {
+    if let Some(name) = explicit {
+        return Ok(name.to_string());
+    }
+    file.default.clone().ok_or_else(|| {
+        pay_core::Error::Config(
+            "no default policy set — pass <name> or run `pay policy use <name>`".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_usd_basic() {
+        assert_eq!(parse_usd_to_micro("1").unwrap(), 1_000_000);
+        assert_eq!(parse_usd_to_micro("0.10").unwrap(), 100_000);
+        assert_eq!(parse_usd_to_micro("$1.25").unwrap(), 1_250_000);
+        assert_eq!(parse_usd_to_micro("0.000001 USDC").unwrap(), 1);
+    }
+
+    #[test]
+    fn parse_usd_rejects_invalid() {
+        assert!(parse_usd_to_micro("").is_err());
+        assert!(parse_usd_to_micro("-1").is_err());
+        assert!(parse_usd_to_micro("abc").is_err());
+        assert!(parse_usd_to_micro("1.0000001").is_err());
+    }
+
+    #[test]
+    fn format_usd_strips_trailing_zeros() {
+        assert_eq!(format_usd(1_000_000), "$1");
+        assert_eq!(format_usd(1_250_000), "$1.25");
+        assert_eq!(format_usd(1), "$0.000001");
+    }
+
+    #[test]
+    fn classify_recognizes_pubkey_and_host() {
+        // Real base58 32-byte pubkey.
+        let pk = "11111111111111111111111111111111";
+        assert!(matches!(classify_allow_value(pk), AllowKind::Recipient(_)));
+        assert!(matches!(
+            classify_allow_value("api.example.com"),
+            AllowKind::Origin(_)
+        ));
+        // A short string that decodes as base58 but is too short.
+        assert!(matches!(
+            classify_allow_value("abc"),
+            AllowKind::Origin(_)
+        ));
+    }
+}

--- a/rust/crates/cli/src/commands/policy/pause.rs
+++ b/rust/crates/cli/src/commands/policy/pause.rs
@@ -1,0 +1,37 @@
+//! `pay policy pause [name]` — flip the kill switch.
+
+use pay_core::policy::PolicyStore;
+
+use super::{load_policy_or_error, resolve_target_name};
+
+#[derive(clap::Args)]
+pub struct PauseCommand {
+    /// Policy name. Defaults to the configured default.
+    pub name: Option<String>,
+}
+
+impl PauseCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file = PolicyStore::load_policies(&store)?;
+        let target = resolve_target_name(self.name.as_deref(), &file)?;
+        let (_, mut policy) = load_policy_or_error(&store, &target)?;
+        if policy.paused {
+            crate::components::print_notice(
+                crate::components::NoticeLevel::Info,
+                &format!("Policy `{target}` was already paused"),
+                "No change.",
+            );
+            return Ok(());
+        }
+        policy.paused = true;
+        file.upsert(policy);
+        PolicyStore::save_policies(&store, &file)?;
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Paused policy `{target}`"),
+            "Every paid request will reject until you run `pay policy resume`.",
+        );
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/policy/resume.rs
+++ b/rust/crates/cli/src/commands/policy/resume.rs
@@ -1,0 +1,37 @@
+//! `pay policy resume [name]` — un-pause a policy.
+
+use pay_core::policy::PolicyStore;
+
+use super::{load_policy_or_error, resolve_target_name};
+
+#[derive(clap::Args)]
+pub struct ResumeCommand {
+    /// Policy name. Defaults to the configured default.
+    pub name: Option<String>,
+}
+
+impl ResumeCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file = PolicyStore::load_policies(&store)?;
+        let target = resolve_target_name(self.name.as_deref(), &file)?;
+        let (_, mut policy) = load_policy_or_error(&store, &target)?;
+        if !policy.paused {
+            crate::components::print_notice(
+                crate::components::NoticeLevel::Info,
+                &format!("Policy `{target}` was not paused"),
+                "No change.",
+            );
+            return Ok(());
+        }
+        policy.paused = false;
+        file.upsert(policy);
+        PolicyStore::save_policies(&store, &file)?;
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Resumed policy `{target}`"),
+            "Future paid requests will be evaluated against the policy rules.",
+        );
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/policy/status.rs
+++ b/rust/crates/cli/src/commands/policy/status.rs
@@ -1,0 +1,133 @@
+//! `pay policy status [name]` — show rules + remaining daily budget.
+
+use chrono::{Duration, Utc};
+use owo_colors::OwoColorize;
+use pay_core::policy::PolicyStore;
+
+use super::{format_usd, load_policy_or_error, resolve_target_name};
+
+#[derive(clap::Args)]
+pub struct StatusCommand {
+    /// Policy name. Defaults to the configured default.
+    pub name: Option<String>,
+
+    /// JSON output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl StatusCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let file = PolicyStore::load_policies(&store)?;
+        let target = resolve_target_name(self.name.as_deref(), &file)?;
+        let (_file, policy) = load_policy_or_error(&store, &target)?;
+        let state = PolicyStore::load_state(&store)?;
+        let now = Utc::now();
+
+        let per = state.per_policy.get(&policy.name);
+        let spent_today = per.map(|s| s.spent_today).unwrap_or(0);
+        let needs_reset = per
+            .and_then(|s| s.day_reset_ts)
+            .is_none_or(|ts| now - ts >= Duration::seconds(86_400));
+        let effective_spent = if needs_reset { 0 } else { spent_today };
+        let remaining = policy.daily_cap.saturating_sub(effective_spent);
+        let pct_used = effective_spent
+            .saturating_mul(100)
+            .checked_div(policy.daily_cap)
+            .map(|p| p.min(100))
+            .unwrap_or(0);
+
+        let day_resets_in = per
+            .and_then(|s| s.day_reset_ts)
+            .map(|ts| {
+                let next = ts + Duration::seconds(86_400);
+                if next > now {
+                    Some(next - now)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(None);
+
+        let status_label = if policy.paused {
+            "paused"
+        } else if let Some(exp) = policy.expires_at
+            && exp <= now
+        {
+            "expired"
+        } else {
+            "active"
+        };
+
+        if self.json || crate::no_dna::should_json(None) {
+            crate::output::print_json(&serde_json::json!({
+                "name": policy.name,
+                "status": status_label,
+                "max_per_tx_micro": policy.max_per_tx,
+                "daily_cap_micro": policy.daily_cap,
+                "spent_today_micro": effective_spent,
+                "remaining_today_micro": remaining,
+                "expires_at": policy.expires_at,
+                "paused": policy.paused,
+                "allowed_recipients": policy.allowed_recipients,
+                "allowed_origins": policy.allowed_origins,
+                "day_reset_ts": per.and_then(|s| s.day_reset_ts),
+                "last_paid_at": per.and_then(|s| s.last_paid_at),
+            }))?;
+            return Ok(());
+        }
+
+        println!("Policy: {}", policy.name.bold());
+        println!("  Status:        {status_label}");
+        println!("  Per-tx cap:    {}", format_usd(policy.max_per_tx));
+        println!("  Daily cap:     {}", format_usd(policy.daily_cap));
+        println!(
+            "  Spent today:   {} ({}%)",
+            format_usd(effective_spent),
+            pct_used
+        );
+        println!("  Remaining:     {}", format_usd(remaining));
+        match day_resets_in {
+            Some(d) => {
+                let hours = d.num_hours();
+                let mins = (d.num_minutes() - hours * 60).abs();
+                println!("  Day resets:    in {hours}h {mins}m");
+            }
+            None => println!("  Day resets:    next paid request"),
+        }
+        if policy.allowed_recipients.is_empty() {
+            println!("  Recipients:    {}", "(any)".dimmed());
+        } else {
+            println!("  Recipients:    {}", policy.allowed_recipients.join(", "));
+        }
+        if policy.allowed_origins.is_empty() {
+            println!("  Origins:       {}", "(any)".dimmed());
+        } else {
+            println!("  Origins:       {}", policy.allowed_origins.join(", "));
+        }
+        match policy.expires_at {
+            Some(exp) => {
+                let remaining = exp - now;
+                if remaining > Duration::zero() {
+                    println!(
+                        "  Expires:       {} (in {}d)",
+                        exp.format("%Y-%m-%d"),
+                        remaining.num_days()
+                    );
+                } else {
+                    println!("  Expires:       {} (expired)", exp.format("%Y-%m-%d"));
+                }
+            }
+            None => println!("  Expires:       {}", "(never)".dimmed()),
+        }
+        println!();
+        eprintln!(
+            "{}",
+            "Note: spent_today is best-effort tracking by the pay CLI. \
+             For actual on-chain balance, run `pay whoami`."
+                .dimmed()
+        );
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/policy/update.rs
+++ b/rust/crates/cli/src/commands/policy/update.rs
@@ -1,0 +1,122 @@
+//! `pay policy update <name>` — modify an existing policy in place.
+
+use chrono::{DateTime, Utc};
+use pay_core::policy::PolicyStore;
+
+use super::{AllowKind, classify_allow_value, load_policy_or_error, parse_usd_to_micro};
+
+#[derive(clap::Args)]
+pub struct UpdateCommand {
+    pub name: String,
+
+    /// New per-tx cap.
+    #[arg(long, value_name = "USD")]
+    pub max_per_tx: Option<String>,
+
+    /// New daily cap.
+    #[arg(long, value_name = "USD")]
+    pub daily_cap: Option<String>,
+
+    /// Replace the entire allow list with these values. Repeatable. Mutually
+    /// exclusive with `--add-allow` / `--remove-allow`.
+    #[arg(long = "allow", value_name = "PUBKEY_OR_HOST", action = clap::ArgAction::Append, conflicts_with_all = ["add_allow", "remove_allow"])]
+    pub allow: Vec<String>,
+
+    /// Append values to the allow list. Repeatable.
+    #[arg(long = "add-allow", value_name = "PUBKEY_OR_HOST", action = clap::ArgAction::Append)]
+    pub add_allow: Vec<String>,
+
+    /// Remove values from the allow list. Repeatable.
+    #[arg(long = "remove-allow", value_name = "PUBKEY_OR_HOST", action = clap::ArgAction::Append)]
+    pub remove_allow: Vec<String>,
+
+    /// New expiry. Pass an empty string to clear.
+    #[arg(long, value_name = "ISO8601")]
+    pub expires: Option<String>,
+}
+
+impl UpdateCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file = PolicyStore::load_policies(&store)?;
+        let (_, mut policy) = load_policy_or_error(&store, &self.name)?;
+
+        if let Some(s) = self.max_per_tx.as_deref() {
+            policy.max_per_tx = parse_usd_to_micro(s)?;
+        }
+        if let Some(s) = self.daily_cap.as_deref() {
+            policy.daily_cap = parse_usd_to_micro(s)?;
+        }
+        if policy.daily_cap < policy.max_per_tx {
+            return Err(pay_core::Error::Config(
+                "daily cap cannot be smaller than per-tx cap".to_string(),
+            ));
+        }
+
+        if !self.allow.is_empty() {
+            policy.allowed_recipients.clear();
+            policy.allowed_origins.clear();
+            for raw in &self.allow {
+                match classify_allow_value(raw) {
+                    AllowKind::Recipient(p) => policy.allowed_recipients.push(p),
+                    AllowKind::Origin(h) => policy.allowed_origins.push(h),
+                }
+            }
+        }
+        for raw in &self.add_allow {
+            match classify_allow_value(raw) {
+                AllowKind::Recipient(p) => {
+                    if !policy.allowed_recipients.contains(&p) {
+                        policy.allowed_recipients.push(p);
+                    }
+                }
+                AllowKind::Origin(h) => {
+                    if !policy.allowed_origins.contains(&h) {
+                        policy.allowed_origins.push(h);
+                    }
+                }
+            }
+        }
+        for raw in &self.remove_allow {
+            match classify_allow_value(raw) {
+                AllowKind::Recipient(p) => policy.allowed_recipients.retain(|x| x != &p),
+                AllowKind::Origin(h) => policy.allowed_origins.retain(|x| x != &h),
+            }
+        }
+
+        if let Some(s) = self.expires.as_deref() {
+            if s.trim().is_empty() {
+                policy.expires_at = None;
+            } else {
+                policy.expires_at = Some(parse_iso8601(s)?);
+            }
+        }
+
+        file.upsert(policy);
+        PolicyStore::save_policies(&store, &file)?;
+
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Updated policy `{}`", self.name),
+            &format!("Run `pay policy status {}` to inspect.", self.name),
+        );
+        Ok(())
+    }
+}
+
+// Local copy — `chrono::DateTime::parse_from_rfc3339` is the canonical path,
+// but we accept a bare `YYYY-MM-DD` for nicer CLI ergonomics.
+fn parse_iso8601(s: &str) -> pay_core::Result<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        let naive = date
+            .and_hms_opt(23, 59, 59)
+            .ok_or_else(|| pay_core::Error::Config(format!("invalid date `{s}`")))?;
+        return Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc));
+    }
+    Err(pay_core::Error::Config(format!(
+        "--expires `{s}` is not a valid ISO 8601 timestamp or YYYY-MM-DD date"
+    )))
+}

--- a/rust/crates/cli/src/commands/policy/use_cmd.rs
+++ b/rust/crates/cli/src/commands/policy/use_cmd.rs
@@ -1,0 +1,46 @@
+//! `pay policy use <name>` — set the default policy.
+
+use pay_core::policy::PolicyStore;
+
+#[derive(clap::Args)]
+pub struct UseCommand {
+    /// Policy name. Pass an empty string `""` (or `--clear`) to remove the
+    /// default and revert to no-policy-by-default behavior.
+    pub name: Option<String>,
+
+    /// Clear the default instead of setting one.
+    #[arg(long, conflicts_with = "name")]
+    pub clear: bool,
+}
+
+impl UseCommand {
+    pub fn run(self) -> pay_core::Result<()> {
+        let store = pay_core::policy::FilePolicyStore::default_path();
+        let mut file = PolicyStore::load_policies(&store)?;
+
+        if self.clear {
+            file.default = None;
+            PolicyStore::save_policies(&store, &file)?;
+            crate::components::print_notice(
+                crate::components::NoticeLevel::Success,
+                "Cleared default policy",
+                "Paid requests will run without policy enforcement unless --policy or per-account binding is set.",
+            );
+            return Ok(());
+        }
+
+        let name = self.name.ok_or_else(|| {
+            pay_core::Error::Config("provide a policy name or pass --clear".to_string())
+        })?;
+        file.set_default(&name).ok_or_else(|| {
+            pay_core::Error::Config(format!("policy `{name}` not found"))
+        })?;
+        PolicyStore::save_policies(&store, &file)?;
+        crate::components::print_notice(
+            crate::components::NoticeLevel::Success,
+            &format!("Default policy is now `{name}`"),
+            "Paid requests will use this policy unless --policy <other> overrides.",
+        );
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/commands/send.rs
+++ b/rust/crates/cli/src/commands/send.rs
@@ -511,6 +511,7 @@ mod tests {
             path: None,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         }
     }
 

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -1981,6 +1981,7 @@ endpoints:
             path: None,
             secret_key_b58: Some(bs58::encode(&VALID_TEST_KEYPAIR_BYTES[..]).into_string()),
             created_at: Some("2026-04-10T00:00:00Z".to_string()),
+            policy: None,
         };
         (acct, pubkey)
     }
@@ -2100,6 +2101,7 @@ endpoints:
             // Valid base58 but wrong length (decodes to <64 bytes).
             secret_key_b58: Some("abc".to_string()),
             created_at: Some("2026-04-10T00:00:00Z".to_string()),
+            policy: None,
         };
         file.upsert(pay_core::accounts::MAINNET_NETWORK, "broken", bad);
         let store = MemoryAccountsStore::with_file(file);

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -69,6 +69,12 @@ struct Opts {
     #[arg(long, global = true)]
     account: Option<String>,
 
+    /// Apply this named spending policy from `~/.config/pay/policies.toml`
+    /// to the current invocation. Overrides any per-account binding and the
+    /// `policies.default` setting.
+    #[arg(long, global = true, value_name = "NAME")]
+    policy: Option<String>,
+
     /// Launch the Payment Debugger proxy on port 1402. All MCP curl
     /// requests are routed through it, and the PDB UI is served at
     /// http://127.0.0.1:1402/
@@ -211,6 +217,7 @@ fn main() {
             command,
             Command::Setup(_)
                 | Command::Account { .. }
+                | Command::Policy { .. }
                 | Command::Whoami(_)
                 | Command::Skills { .. }
                 | Command::Catalog { .. }
@@ -277,6 +284,7 @@ fn main() {
         keypair_override.as_deref(),
         network_override.as_deref(),
         opts.account.as_deref(),
+        opts.policy.as_deref(),
         verbose,
         sandbox_mode,
     ) {

--- a/rust/crates/core/src/accounts.rs
+++ b/rust/crates/core/src/accounts.rs
@@ -139,6 +139,12 @@ pub struct Account {
     /// ephemerals may have less SOL because faucets reset).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
+
+    /// Optional spending-policy name to apply for paid requests using this
+    /// account. Resolved against `~/.config/pay/policies.toml`. Overridden
+    /// by the per-invocation `--policy <name>` flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
 }
 
 impl Account {
@@ -570,6 +576,7 @@ fn generate_ephemeral_account() -> Account {
         path: None,
         secret_key_b58: Some(bs58::encode(&full).into_string()),
         created_at: Some(now_rfc3339()),
+        policy: None,
     }
 }
 
@@ -642,6 +649,7 @@ mod tests {
             account: None,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         }
     }
 
@@ -656,6 +664,7 @@ mod tests {
             path: None,
             secret_key_b58: Some("test-secret-bytes-base58".to_string()),
             created_at: Some("2026-04-10T00:00:00Z".to_string()),
+            policy: None,
         }
     }
 
@@ -710,6 +719,7 @@ mod tests {
             account: None,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         };
         assert_eq!(
             acct.signer_source("legacy"),
@@ -729,6 +739,7 @@ mod tests {
             account: None,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         };
         assert_eq!(
             acct.signer_source("myacct"),
@@ -749,6 +760,7 @@ mod tests {
             path: None,
             secret_key_b58: Some(bs58::encode(&raw_bytes).into_string()),
             created_at: Some("2026-04-10T00:00:00Z".to_string()),
+            policy: None,
         };
         assert_eq!(acct.ephemeral_keypair_bytes(), Some(raw_bytes));
     }

--- a/rust/crates/core/src/client/mpp.rs
+++ b/rust/crates/core/src/client/mpp.rs
@@ -18,6 +18,20 @@ use crate::{Error, Result};
 // Re-export the challenge type for the runner/CLI.
 pub use solana_mpp::PaymentChallenge as Challenge;
 
+/// Extract the priced amount from an MPP challenge as micro-USDC.
+///
+/// Decodes the inner `ChargeRequest`, then runs it through the same
+/// stablecoin-amount parser used by the policy gate. Lets callers in
+/// downstream crates (e.g. `pay-mcp`) record the spend after a successful
+/// retry without needing a direct `solana-mpp` dependency.
+pub fn amount_micro_usdc_from_challenge(challenge: &Challenge) -> Result<u64> {
+    let request: ChargeRequest = challenge
+        .request
+        .decode()
+        .map_err(|e| Error::Mpp(format!("Failed to decode challenge request: {e}")))?;
+    crate::policy::parse_amount_micro_usdc(&request.amount, &request.currency)
+}
+
 /// Try to extract an MPP challenge from the `www-authenticate` header value.
 pub fn parse(header_value: &str) -> Option<Challenge> {
     parse_all([header_value]).into_iter().next()
@@ -60,11 +74,32 @@ pub fn build_credential(
     network_override: Option<&str>,
     account_override: Option<&str>,
     resource_url: Option<&str>,
+    policy_ctx: Option<&crate::policy::PolicyContext<'_>>,
 ) -> Result<(String, Option<ResolvedEphemeral>)> {
     let request: ChargeRequest = challenge
         .request
         .decode()
         .map_err(|e| Error::Mpp(format!("Failed to decode challenge request: {e}")))?;
+
+    // Run the policy gate before any keystore access so a rejected request
+    // never triggers Touch ID. We rely on the existing PaymentRejected error
+    // path so the CLI / MCP rendering stays unchanged.
+    if let Some(ctx) = policy_ctx {
+        let amount_micro =
+            crate::policy::parse_amount_micro_usdc(&request.amount, &request.currency)?;
+        let origin = crate::policy::extract_origin(resource_url);
+        // MPP `recipient` is optional in the upstream type; fall back to
+        // empty string so allowlist mismatch surfaces as a real reject
+        // rather than a silent pass.
+        let recipient = request.recipient.as_deref().unwrap_or("");
+        crate::policy::gate_payment_with_store(
+            ctx,
+            amount_micro,
+            recipient,
+            origin.as_deref(),
+            chrono::Utc::now(),
+        )?;
+    }
 
     let amount = format_amount(&request.amount, &request.currency);
     let prompt_context = crate::client::prompt::payment_prompt_context(

--- a/rust/crates/core/src/client/send.rs
+++ b/rust/crates/core/src/client/send.rs
@@ -201,6 +201,9 @@ pub fn send_stablecoin(request: StablecoinSendRequest<'_>) -> Result<SendResult>
         Some(network),
         account_override,
         Some(&api_url),
+        // `pay send` is the user explicitly transferring funds, not an
+        // automated paid-API call — bypass policy enforcement.
+        None,
     )?;
 
     let retry_headers = vec![

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -477,6 +477,7 @@ mod tests {
                 path: None,
                 secret_key_b58: Some(bs58::encode(keypair.to_bytes()).into_string()),
                 created_at: Some("2026-04-19T00:00:00Z".to_string()),
+                policy: None,
             },
         );
         MemoryAccountsStore::with_file(file)

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -28,6 +28,18 @@ use crate::{Error, Result};
 
 pub use solana_x402::{SIGN_IN_WITH_X_HEADER, X402_V1_PAYMENT_HEADER, X402_V2_PAYMENT_HEADER};
 
+/// Extract the priced amount from an x402 challenge as micro-USDC.
+///
+/// Mirrors [`crate::client::mpp::amount_micro_usdc_from_challenge`] for the
+/// x402 protocol so downstream crates can record post-payment spend without
+/// reaching for `solana-x402` types directly.
+pub fn amount_micro_usdc_from_challenge(challenge: &Challenge) -> Result<u64> {
+    crate::policy::parse_amount_micro_usdc(
+        &challenge.requirements.amount,
+        &challenge.requirements.currency,
+    )
+}
+
 #[derive(Debug, Clone)]
 pub struct Challenge {
     pub x402_version: u64,
@@ -89,8 +101,25 @@ pub fn build_payment(
     network_override: Option<&str>,
     account_override: Option<&str>,
     resource_url: Option<&str>,
+    policy_ctx: Option<&crate::policy::PolicyContext<'_>>,
 ) -> Result<BuiltPayment> {
     let requirements = &challenge.requirements;
+
+    // Policy gate runs before signer load — rejected requests never
+    // surface a Touch ID prompt.
+    if let Some(ctx) = policy_ctx {
+        let amount_micro =
+            crate::policy::parse_amount_micro_usdc(&requirements.amount, &requirements.currency)?;
+        let origin = crate::policy::extract_origin(resource_url);
+        crate::policy::gate_payment_with_store(
+            ctx,
+            amount_micro,
+            &requirements.recipient,
+            origin.as_deref(),
+            chrono::Utc::now(),
+        )?;
+    }
+
     let amount = format_amount(&requirements.amount, &requirements.currency);
     let prompt_context = crate::client::prompt::payment_prompt_context(
         requirements.description.as_deref(),
@@ -183,12 +212,17 @@ pub fn build_payment(
 }
 
 /// Build a signed x402 SIWX-only retry header.
+///
+/// SIWX is a sign-in flow with no on-chain payment, so policy enforcement
+/// is a no-op here even when a `policy_ctx` is supplied — the parameter is
+/// accepted for signature symmetry with [`build_payment`].
 pub fn build_siwx_auth_header(
     challenge: &SiwxAuthChallenge,
     store: &dyn AccountsStore,
     network_override: Option<&str>,
     account_override: Option<&str>,
     resource_url: Option<&str>,
+    _policy_ctx: Option<&crate::policy::PolicyContext<'_>>,
 ) -> Result<BuiltPayment> {
     let preferred_chain_id = network_override.and_then(siwx_chain_id_for_network);
     let chain = solana_x402::siwx::select_siwx_chain(
@@ -860,6 +894,7 @@ mod tests {
             path: None,
             secret_key_b58: Some(bs58::encode(TEST_KEYPAIR_BYTES).into_string()),
             created_at: Some("2026-04-27T00:00:00Z".to_string()),
+            policy: None,
         };
         let mut file = AccountsFile::default();
         file.upsert("devnet", "default", account);
@@ -882,7 +917,7 @@ mod tests {
             ),
         };
 
-        let built = build_siwx_auth_header(&challenge, &store, Some("devnet"), None, None).unwrap();
+        let built = build_siwx_auth_header(&challenge, &store, Some("devnet"), None, None, None).unwrap();
         let payload = solana_x402::siwx::parse_siwx_header(&built.headers[0].1).unwrap();
 
         assert_eq!(built.headers.len(), 1);
@@ -913,7 +948,7 @@ mod tests {
         let store = MemoryAccountsStore::new();
 
         let err =
-            build_siwx_auth_header(&challenge, &store, Some("devnet"), None, None).unwrap_err();
+            build_siwx_auth_header(&challenge, &store, Some("devnet"), None, None, None).unwrap_err();
 
         assert!(
             err.to_string()
@@ -941,7 +976,7 @@ mod tests {
             siwx: None,
         };
 
-        let err = build_payment(&challenge, &store, Some("localnet"), None, None).unwrap_err();
+        let err = build_payment(&challenge, &store, Some("localnet"), None, None, None).unwrap_err();
         let msg = err.to_string();
 
         assert!(msg.contains("you forced network `localnet`"));
@@ -962,7 +997,7 @@ mod tests {
             siwx: None,
         };
 
-        let err = build_payment(&challenge, &store, None, None, None).unwrap_err();
+        let err = build_payment(&challenge, &store, None, None, None, None).unwrap_err();
         let msg = err.to_string();
 
         assert!(msg.contains("No account configured for network `mainnet`"));
@@ -979,7 +1014,7 @@ mod tests {
             requirements,
             siwx: None,
         };
-        let err = build_payment(&challenge, &store, None, Some("alice"), None).unwrap_err();
+        let err = build_payment(&challenge, &store, None, Some("alice"), None, None).unwrap_err();
         let msg = err.to_string();
 
         assert!(msg.contains("No account named `alice` configured for network `mainnet`"));

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod error;
 pub mod instructions;
 pub mod keystore;
+pub mod policy;
 pub mod signer;
 pub mod skills;
 

--- a/rust/crates/core/src/policy/check.rs
+++ b/rust/crates/core/src/policy/check.rs
@@ -1,0 +1,492 @@
+//! Pure policy-check logic. No I/O — call this from the 402 builders after
+//! loading state and before loading the signer.
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::config::Policy;
+use super::state::PerPolicyState;
+
+const ONE_DAY: Duration = Duration::seconds(86_400);
+
+/// Why a policy rejected a payment. Carries enough detail to render a
+/// helpful CLI error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyViolation {
+    Paused,
+    Expired { expired_at: DateTime<Utc> },
+    ExceedsPerTx { amount: u64, max: u64 },
+    ExceedsDailyCap { spent: u64, amount: u64, cap: u64 },
+    RecipientNotAllowed { recipient: String },
+    OriginNotAllowed { origin: String },
+    /// Both lists are set but the request matched neither.
+    NoAllowlistMatch {
+        recipient: Option<String>,
+        origin: Option<String>,
+    },
+}
+
+impl PolicyViolation {
+    /// One-line user-facing message for the CLI / MCP error response.
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::Paused => "policy is paused".to_string(),
+            Self::Expired { expired_at } => {
+                format!("policy expired at {}", expired_at.to_rfc3339())
+            }
+            Self::ExceedsPerTx { amount, max } => format!(
+                "amount {} exceeds per-tx cap {} (micro-USDC)",
+                amount, max
+            ),
+            Self::ExceedsDailyCap {
+                spent,
+                amount,
+                cap,
+            } => format!(
+                "daily cap exceeded: would spend {} of {} (already spent {}, all micro-USDC)",
+                spent + amount,
+                cap,
+                spent,
+            ),
+            Self::RecipientNotAllowed { recipient } => {
+                format!("recipient {recipient} is not in policy allowlist")
+            }
+            Self::OriginNotAllowed { origin } => {
+                format!("request origin {origin} is not in policy allowlist")
+            }
+            Self::NoAllowlistMatch { recipient, origin } => format!(
+                "neither recipient ({}) nor origin ({}) matches policy allowlists",
+                recipient.as_deref().unwrap_or("?"),
+                origin.as_deref().unwrap_or("?"),
+            ),
+        }
+    }
+}
+
+/// Run the policy gate for a single about-to-be-signed payment.
+///
+/// On success, the daily-window roll has happened in-place on `state` (if
+/// applicable) and the caller should persist `state` if it was mutated. On
+/// failure, `state` is unchanged.
+///
+/// Both allowlist semantics:
+/// - Both empty ⇒ no allowlist restriction.
+/// - One non-empty ⇒ that list must match.
+/// - Both non-empty ⇒ either match passes.
+pub fn check_payment(
+    policy: &Policy,
+    state: &mut PerPolicyState,
+    amount: u64,
+    recipient: &str,
+    request_origin: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<(), PolicyViolation> {
+    if policy.paused {
+        return Err(PolicyViolation::Paused);
+    }
+    if let Some(expires_at) = policy.expires_at
+        && now >= expires_at
+    {
+        return Err(PolicyViolation::Expired { expired_at: expires_at });
+    }
+    if amount > policy.max_per_tx {
+        return Err(PolicyViolation::ExceedsPerTx {
+            amount,
+            max: policy.max_per_tx,
+        });
+    }
+
+    // Daily-window roll: reset if the existing window is >= 24h old, OR if
+    // there's no recorded window yet (first use).
+    let needs_reset = match state.day_reset_ts {
+        Some(ts) => now - ts >= ONE_DAY,
+        None => true,
+    };
+    if needs_reset {
+        state.spent_today = 0;
+        state.day_reset_ts = Some(now);
+    }
+
+    let new_total = state
+        .spent_today
+        .checked_add(amount)
+        .ok_or(PolicyViolation::ExceedsDailyCap {
+            spent: state.spent_today,
+            amount,
+            cap: policy.daily_cap,
+        })?;
+    if new_total > policy.daily_cap {
+        return Err(PolicyViolation::ExceedsDailyCap {
+            spent: state.spent_today,
+            amount,
+            cap: policy.daily_cap,
+        });
+    }
+
+    // Allowlist check.
+    let recipients_set = !policy.allowed_recipients.is_empty();
+    let origins_set = !policy.allowed_origins.is_empty();
+    if recipients_set || origins_set {
+        let recipient_match =
+            recipients_set && policy.allowed_recipients.iter().any(|r| r == recipient);
+        let origin_match = origins_set
+            && request_origin.is_some_and(|o| policy.allowed_origins.iter().any(|a| a == o));
+
+        if !recipient_match && !origin_match {
+            // Pick the most specific error.
+            return Err(match (recipients_set, origins_set) {
+                (true, false) => PolicyViolation::RecipientNotAllowed {
+                    recipient: recipient.to_string(),
+                },
+                (false, true) => PolicyViolation::OriginNotAllowed {
+                    origin: request_origin.unwrap_or("(none)").to_string(),
+                },
+                _ => PolicyViolation::NoAllowlistMatch {
+                    recipient: Some(recipient.to_string()),
+                    origin: request_origin.map(str::to_string),
+                },
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Increment `spent_today` and update `last_paid_at` after a successful
+/// HTTP retry. Caller persists the state file.
+pub fn record_payment(state: &mut PerPolicyState, amount: u64, now: DateTime<Utc>) {
+    state.spent_today = state.spent_today.saturating_add(amount);
+    state.last_paid_at = Some(now);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn base_policy() -> Policy {
+        Policy {
+            name: "test".to_string(),
+            max_per_tx: 100_000,
+            daily_cap: 1_000_000,
+            allowed_recipients: vec![],
+            allowed_origins: vec![],
+            expires_at: None,
+            paused: false,
+            created_at: t("2026-01-01T00:00:00Z"),
+        }
+    }
+
+    #[test]
+    fn happy_path() {
+        let policy = base_policy();
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            50_000,
+            "RecipientPubkey",
+            Some("api.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn paused_blocks() {
+        let mut policy = base_policy();
+        policy.paused = true;
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "X",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert_eq!(result, Err(PolicyViolation::Paused));
+    }
+
+    #[test]
+    fn expired_blocks() {
+        let mut policy = base_policy();
+        policy.expires_at = Some(t("2026-04-01T00:00:00Z"));
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "X",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(matches!(result, Err(PolicyViolation::Expired { .. })));
+    }
+
+    #[test]
+    fn exceeds_per_tx() {
+        let policy = base_policy();
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            100_001,
+            "X",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert_eq!(
+            result,
+            Err(PolicyViolation::ExceedsPerTx {
+                amount: 100_001,
+                max: 100_000,
+            })
+        );
+    }
+
+    #[test]
+    fn exceeds_daily_cap() {
+        let policy = base_policy();
+        let mut state = PerPolicyState {
+            spent_today: 950_000,
+            day_reset_ts: Some(t("2026-05-01T00:00:00Z")),
+            last_paid_at: None,
+        };
+        let result = check_payment(
+            &policy,
+            &mut state,
+            100_000,
+            "X",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert_eq!(
+            result,
+            Err(PolicyViolation::ExceedsDailyCap {
+                spent: 950_000,
+                amount: 100_000,
+                cap: 1_000_000,
+            })
+        );
+    }
+
+    #[test]
+    fn daily_window_resets_after_24h() {
+        let policy = base_policy();
+        let mut state = PerPolicyState {
+            spent_today: 950_000,
+            day_reset_ts: Some(t("2026-05-01T00:00:00Z")),
+            last_paid_at: None,
+        };
+        // 24h after the window opened, the counter should reset and the
+        // amount should now fit.
+        let now = t("2026-05-02T00:00:01Z");
+        let result = check_payment(&policy, &mut state, 100_000, "X", None, now);
+        assert!(result.is_ok());
+        assert_eq!(state.spent_today, 0); // reset happens before the (deferred) increment
+        assert_eq!(state.day_reset_ts, Some(now));
+    }
+
+    #[test]
+    fn first_use_seeds_window() {
+        let policy = base_policy();
+        let mut state = PerPolicyState::default();
+        let now = t("2026-05-01T12:00:00Z");
+        let result = check_payment(&policy, &mut state, 10, "X", None, now);
+        assert!(result.is_ok());
+        assert_eq!(state.day_reset_ts, Some(now));
+    }
+
+    #[test]
+    fn recipient_allowlist_hit() {
+        let mut policy = base_policy();
+        policy.allowed_recipients = vec!["GoodRecipient".to_string()];
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "GoodRecipient",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn recipient_allowlist_miss() {
+        let mut policy = base_policy();
+        policy.allowed_recipients = vec!["GoodRecipient".to_string()];
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "OtherRecipient",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert_eq!(
+            result,
+            Err(PolicyViolation::RecipientNotAllowed {
+                recipient: "OtherRecipient".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn origin_allowlist_hit() {
+        let mut policy = base_policy();
+        policy.allowed_origins = vec!["api.example.com".to_string()];
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "X",
+            Some("api.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn origin_allowlist_miss() {
+        let mut policy = base_policy();
+        policy.allowed_origins = vec!["api.example.com".to_string()];
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "X",
+            Some("other.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert_eq!(
+            result,
+            Err(PolicyViolation::OriginNotAllowed {
+                origin: "other.example.com".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn both_allowlists_or_semantics_either_passes() {
+        let mut policy = base_policy();
+        policy.allowed_recipients = vec!["GoodRecipient".to_string()];
+        policy.allowed_origins = vec!["api.example.com".to_string()];
+
+        // Recipient matches, origin doesn't → pass (OR).
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "GoodRecipient",
+            Some("other.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(result.is_ok());
+
+        // Origin matches, recipient doesn't → pass (OR).
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "OtherRecipient",
+            Some("api.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(result.is_ok());
+
+        // Neither matches → reject with NoAllowlistMatch.
+        let mut state = PerPolicyState::default();
+        let result = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "OtherRecipient",
+            Some("other.example.com"),
+            t("2026-05-01T12:00:00Z"),
+        );
+        assert!(matches!(
+            result,
+            Err(PolicyViolation::NoAllowlistMatch { .. })
+        ));
+    }
+
+    #[test]
+    fn record_payment_increments_and_timestamps() {
+        let mut state = PerPolicyState::default();
+        let now = t("2026-05-01T12:00:00Z");
+        record_payment(&mut state, 50_000, now);
+        assert_eq!(state.spent_today, 50_000);
+        assert_eq!(state.last_paid_at, Some(now));
+
+        record_payment(&mut state, 25_000, now);
+        assert_eq!(state.spent_today, 75_000);
+    }
+
+    #[test]
+    fn record_payment_saturates_on_overflow() {
+        let mut state = PerPolicyState {
+            spent_today: u64::MAX - 5,
+            day_reset_ts: None,
+            last_paid_at: None,
+        };
+        record_payment(&mut state, 100, t("2026-05-01T12:00:00Z"));
+        assert_eq!(state.spent_today, u64::MAX);
+    }
+
+    #[test]
+    fn rejection_does_not_mutate_state_for_paused() {
+        let mut policy = base_policy();
+        policy.paused = true;
+        let mut state = PerPolicyState {
+            spent_today: 500_000,
+            day_reset_ts: Some(t("2026-04-01T00:00:00Z")),
+            last_paid_at: None,
+        };
+        let snapshot = state.clone();
+        let _ = check_payment(
+            &policy,
+            &mut state,
+            10,
+            "X",
+            None,
+            t("2026-05-01T12:00:00Z"),
+        );
+        // Day-roll should not happen if paused (we bail before).
+        assert_eq!(state.spent_today, snapshot.spent_today);
+        assert_eq!(state.day_reset_ts, snapshot.day_reset_ts);
+    }
+
+    #[test]
+    fn user_messages_are_human_readable() {
+        let messages = [
+            PolicyViolation::Paused.user_message(),
+            PolicyViolation::ExceedsPerTx {
+                amount: 1,
+                max: 0,
+            }
+            .user_message(),
+            PolicyViolation::ExceedsDailyCap {
+                spent: 1,
+                amount: 1,
+                cap: 1,
+            }
+            .user_message(),
+        ];
+        for m in messages {
+            assert!(!m.is_empty());
+            assert!(m.is_ascii());
+        }
+    }
+}

--- a/rust/crates/core/src/policy/config.rs
+++ b/rust/crates/core/src/policy/config.rs
@@ -1,0 +1,173 @@
+//! Policy definitions persisted to `~/.config/pay/policies.toml`.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Current schema version. Bumped on incompatible changes.
+pub const POLICIES_SCHEMA_VERSION: u32 = 1;
+
+/// A single named spending policy.
+///
+/// All amounts are micro-USDC (six decimal places). An empty allowlist means
+/// "any" — both lists empty is the wide-open default. When *both* lists are
+/// non-empty, a request passes if it matches *either* (OR semantics).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Policy {
+    /// Human-readable name; also the key in [`PoliciesFile::policies`]. The
+    /// name is duplicated here so a `Policy` value carries its own identity
+    /// once removed from the map.
+    pub name: String,
+
+    /// Per-transaction cap in micro-USDC. Reject if `amount > max_per_tx`.
+    pub max_per_tx: u64,
+
+    /// Daily cap in micro-USDC. Reject if `spent_today + amount > daily_cap`.
+    pub daily_cap: u64,
+
+    /// Allowlisted recipient base58 wallet pubkeys. Empty ⇒ no restriction
+    /// from this list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_recipients: Vec<String>,
+
+    /// Allowlisted request URL hosts (e.g. `api.example.com`). Empty ⇒ no
+    /// restriction from this list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_origins: Vec<String>,
+
+    /// Optional expiry. Reject after this timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Hard kill switch. When true, every request is rejected.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub paused: bool,
+
+    /// When this policy was created (informational).
+    pub created_at: DateTime<Utc>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
+/// Top-level on-disk shape of `policies.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoliciesFile {
+    /// Schema version. Bumped on incompatible changes.
+    #[serde(default = "default_version")]
+    pub version: u32,
+
+    /// Optional default policy name. Used when the user has not passed
+    /// `--policy <name>` and the active account has no `policy` binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+
+    /// Named policies. `BTreeMap` for deterministic on-disk order.
+    #[serde(default)]
+    pub policies: BTreeMap<String, Policy>,
+}
+
+impl Default for PoliciesFile {
+    fn default() -> Self {
+        Self {
+            version: POLICIES_SCHEMA_VERSION,
+            default: None,
+            policies: BTreeMap::new(),
+        }
+    }
+}
+
+fn default_version() -> u32 {
+    POLICIES_SCHEMA_VERSION
+}
+
+impl PoliciesFile {
+    /// Look up a policy by name.
+    pub fn get(&self, name: &str) -> Option<&Policy> {
+        self.policies.get(name)
+    }
+
+    /// Insert or overwrite a policy.
+    pub fn upsert(&mut self, policy: Policy) {
+        self.policies.insert(policy.name.clone(), policy);
+    }
+
+    /// Remove a policy. Also clears the `default` field if it pointed at
+    /// the removed name.
+    pub fn remove(&mut self, name: &str) -> Option<Policy> {
+        let removed = self.policies.remove(name);
+        if self.default.as_deref() == Some(name) {
+            self.default = None;
+        }
+        removed
+    }
+
+    /// Set the default policy. Errors via `Option::None` if no policy by
+    /// that name exists; caller decides how to surface that.
+    pub fn set_default(&mut self, name: &str) -> Option<()> {
+        if !self.policies.contains_key(name) {
+            return None;
+        }
+        self.default = Some(name.to_string());
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_policy(name: &str) -> Policy {
+        Policy {
+            name: name.to_string(),
+            max_per_tx: 100_000,
+            daily_cap: 1_000_000,
+            allowed_recipients: vec![],
+            allowed_origins: vec!["api.example.com".to_string()],
+            expires_at: None,
+            paused: false,
+            created_at: DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+
+    #[test]
+    fn toml_roundtrip_minimal() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample_policy("test"));
+        let serialized = toml::to_string(&file).unwrap();
+        let deserialized: PoliciesFile = toml::from_str(&serialized).unwrap();
+        assert_eq!(file.policies, deserialized.policies);
+        assert_eq!(file.version, deserialized.version);
+    }
+
+    #[test]
+    fn toml_skips_empty_optional_fields() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample_policy("test"));
+        let serialized = toml::to_string(&file).unwrap();
+        assert!(!serialized.contains("allowed_recipients"));
+        assert!(!serialized.contains("expires_at"));
+        assert!(!serialized.contains("paused"));
+    }
+
+    #[test]
+    fn remove_clears_default_pointer() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample_policy("a"));
+        file.upsert(sample_policy("b"));
+        file.set_default("a").unwrap();
+        file.remove("a");
+        assert!(file.default.is_none());
+    }
+
+    #[test]
+    fn set_default_rejects_missing_name() {
+        let mut file = PoliciesFile::default();
+        assert!(file.set_default("missing").is_none());
+        assert!(file.default.is_none());
+    }
+}

--- a/rust/crates/core/src/policy/mod.rs
+++ b/rust/crates/core/src/policy/mod.rs
@@ -1,0 +1,196 @@
+//! Local spending-policy enforcement for paid HTTP requests.
+//!
+//! A *policy* is a named, persistent set of rules — per-tx cap, daily cap,
+//! recipient/origin allowlist, expiry, and pause switch — checked inside
+//! `pay` before a 402 challenge is signed. It's the persistent, richer
+//! cousin of the per-invocation `--yolo-upto` cap.
+//!
+//! Two stores back the module:
+//!   - [`PoliciesFile`] (TOML at `~/.config/pay/policies.toml`) — user-edited
+//!     policy definitions plus an optional `default` selector.
+//!   - [`PolicyState`] (JSON at `~/.config/pay/policy-state.json`) — rolling
+//!     `spent_today` per policy, written atomically after a successful pay.
+//!
+//! The check itself is a pure function ([`check_payment`]) so it can be
+//! unit-tested without I/O. State mutation (the daily roll) happens during
+//! the check; the post-payment increment is a separate [`record_payment`]
+//! call so the caller can sequence it after the HTTP retry succeeds.
+
+pub mod check;
+pub mod config;
+pub mod state;
+pub mod store;
+
+pub use check::{PolicyViolation, check_payment, record_payment};
+pub use config::{PoliciesFile, Policy};
+pub use state::{PerPolicyState, PolicyState};
+pub use store::{FilePolicyStore, MemoryPolicyStore, PolicyStore};
+
+/// Resolved policy + a store handle, threaded into the 402 builders to gate
+/// signing and persist post-payment state.
+pub struct PolicyContext<'a> {
+    pub policy: Policy,
+    pub store: &'a dyn PolicyStore,
+}
+
+/// Extract the URL host (lowercased, no port) from a resource URL string.
+/// Returns `None` when the URL is missing or unparseable — callers treat that
+/// as "no origin known" for allowlist purposes.
+pub fn extract_origin(resource_url: Option<&str>) -> Option<String> {
+    let url = resource_url?;
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_lowercase()))
+}
+
+/// Convert an `(amount, currency)` pair from a 402 challenge into micro-USDC.
+///
+/// All Solana stablecoins in the catalog are six-decimal, so the raw `amount`
+/// string is already in micro-units when `currency` is a known stablecoin
+/// symbol (USDC, USDT, …) or mint. Returns `Err` for non-stablecoin
+/// currencies — the policy can't price SOL or other assets safely.
+pub fn parse_amount_micro_usdc(amount: &str, currency: &str) -> crate::Result<u64> {
+    use pay_types::Stablecoin;
+    if Stablecoin::parse_symbol(currency).is_none() && Stablecoin::from_mint(currency).is_none() {
+        return Err(crate::Error::PaymentRejected(format!(
+            "policy is stablecoin-denominated and cannot price `{currency}` payments"
+        )));
+    }
+    amount.parse::<u64>().map_err(|e| {
+        crate::Error::PaymentRejected(format!("invalid stablecoin amount `{amount}`: {e}"))
+    })
+}
+
+/// Run the policy gate (load state → check → persist daily-roll change) and
+/// surface failures as [`crate::Error::PaymentRejected`] for the existing
+/// CLI / MCP rejection paths.
+///
+/// On success, `state` may have rolled the daily window — that case is
+/// persisted. The post-payment increment happens in [`record_payment_with_store`].
+pub fn gate_payment_with_store(
+    ctx: &PolicyContext<'_>,
+    amount_micro_usdc: u64,
+    recipient: &str,
+    request_origin: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> crate::Result<()> {
+    let mut state = ctx.store.load_state()?;
+    let entry = state.entry_mut(&ctx.policy.name);
+    let snapshot_reset = entry.day_reset_ts;
+    let snapshot_spent = entry.spent_today;
+
+    check_payment(&ctx.policy, entry, amount_micro_usdc, recipient, request_origin, now)
+        .map_err(|v| crate::Error::PaymentRejected(format!("policy: {}", v.user_message())))?;
+
+    let rolled =
+        entry.day_reset_ts != snapshot_reset || entry.spent_today != snapshot_spent;
+    if rolled {
+        ctx.store.save_state(&state)?;
+    }
+    Ok(())
+}
+
+/// Increment `spent_today` in the persisted state after a confirmed payment.
+pub fn record_payment_with_store(
+    ctx: &PolicyContext<'_>,
+    amount_micro_usdc: u64,
+    now: chrono::DateTime<chrono::Utc>,
+) -> crate::Result<()> {
+    let mut state = ctx.store.load_state()?;
+    let entry = state.entry_mut(&ctx.policy.name);
+    record_payment(entry, amount_micro_usdc, now);
+    ctx.store.save_state(&state)?;
+    Ok(())
+}
+
+/// Resolve which policy applies for the upcoming payment.
+///
+/// Resolution order:
+///
+/// 1. `--policy <name>` flag → explicit user choice (errors if name missing).
+/// 2. The account's `policy` field → per-account default.
+/// 3. `policies.default` → user-set global default.
+/// 4. `None` → no enforcement (today's behavior).
+pub fn resolve_active_policy(
+    cli_override: Option<&str>,
+    account_policy: Option<&str>,
+    policies: &PoliciesFile,
+) -> Result<Option<Policy>, crate::Error> {
+    let candidate = cli_override
+        .or(account_policy)
+        .or(policies.default.as_deref());
+    let Some(name) = candidate else {
+        return Ok(None);
+    };
+    policies
+        .get(name)
+        .cloned()
+        .map(Some)
+        .ok_or_else(|| crate::Error::Config(format!("policy `{name}` not found in policies.toml")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn sample(name: &str) -> Policy {
+        Policy {
+            name: name.to_string(),
+            max_per_tx: 10_000,
+            daily_cap: 100_000,
+            allowed_recipients: vec![],
+            allowed_origins: vec![],
+            expires_at: None,
+            paused: false,
+            created_at: t("2026-01-01T00:00:00Z"),
+        }
+    }
+
+    #[test]
+    fn cli_override_wins() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample("a"));
+        file.upsert(sample("b"));
+        file.set_default("a").unwrap();
+        let resolved = resolve_active_policy(Some("b"), Some("a"), &file).unwrap();
+        assert_eq!(resolved.unwrap().name, "b");
+    }
+
+    #[test]
+    fn account_policy_used_when_no_cli_flag() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample("a"));
+        file.upsert(sample("b"));
+        file.set_default("a").unwrap();
+        let resolved = resolve_active_policy(None, Some("b"), &file).unwrap();
+        assert_eq!(resolved.unwrap().name, "b");
+    }
+
+    #[test]
+    fn default_used_when_no_cli_or_account() {
+        let mut file = PoliciesFile::default();
+        file.upsert(sample("a"));
+        file.set_default("a").unwrap();
+        let resolved = resolve_active_policy(None, None, &file).unwrap();
+        assert_eq!(resolved.unwrap().name, "a");
+    }
+
+    #[test]
+    fn returns_none_when_nothing_set() {
+        let file = PoliciesFile::default();
+        let resolved = resolve_active_policy(None, None, &file).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn errors_on_unknown_name() {
+        let file = PoliciesFile::default();
+        let err = resolve_active_policy(Some("missing"), None, &file).unwrap_err();
+        assert!(err.to_string().contains("policy `missing` not found"));
+    }
+}

--- a/rust/crates/core/src/policy/state.rs
+++ b/rust/crates/core/src/policy/state.rs
@@ -1,0 +1,62 @@
+//! Per-policy spending state persisted to `~/.config/pay/policy-state.json`.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Current schema version.
+pub const STATE_SCHEMA_VERSION: u32 = 1;
+
+/// Top-level state file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyState {
+    #[serde(default = "default_version")]
+    pub version: u32,
+
+    /// Per-policy rolling state, keyed by policy name.
+    #[serde(default)]
+    pub per_policy: BTreeMap<String, PerPolicyState>,
+}
+
+impl Default for PolicyState {
+    fn default() -> Self {
+        Self {
+            version: STATE_SCHEMA_VERSION,
+            per_policy: BTreeMap::new(),
+        }
+    }
+}
+
+fn default_version() -> u32 {
+    STATE_SCHEMA_VERSION
+}
+
+/// Rolling spend tracker for a single named policy.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PerPolicyState {
+    /// Micro-USDC spent within the current 24-hour window.
+    #[serde(default)]
+    pub spent_today: u64,
+
+    /// When the current 24-hour window started. Reset to "now" each time
+    /// the window rolls over.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub day_reset_ts: Option<DateTime<Utc>>,
+
+    /// Last successful payment timestamp (informational).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_paid_at: Option<DateTime<Utc>>,
+}
+
+impl PolicyState {
+    /// Get-or-insert the per-policy slot for `name`.
+    pub fn entry_mut(&mut self, name: &str) -> &mut PerPolicyState {
+        self.per_policy.entry(name.to_string()).or_default()
+    }
+
+    /// Drop a policy's state (called when the policy is deleted).
+    pub fn forget(&mut self, name: &str) {
+        self.per_policy.remove(name);
+    }
+}

--- a/rust/crates/core/src/policy/store.rs
+++ b/rust/crates/core/src/policy/store.rs
@@ -1,0 +1,280 @@
+//! Pluggable read/write for policies.toml + policy-state.json.
+
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use super::config::PoliciesFile;
+use super::state::PolicyState;
+use crate::{Error, Result};
+
+const POLICIES_FILE: &str = "~/.config/pay/policies.toml";
+const STATE_FILE: &str = "~/.config/pay/policy-state.json";
+
+/// Read/write abstraction. Real impl is [`FilePolicyStore`]; tests use
+/// [`MemoryPolicyStore`].
+pub trait PolicyStore: Send + Sync {
+    fn load_policies(&self) -> Result<PoliciesFile>;
+    fn save_policies(&self, file: &PoliciesFile) -> Result<()>;
+    fn load_state(&self) -> Result<PolicyState>;
+    fn save_state(&self, state: &PolicyState) -> Result<()>;
+}
+
+/// On-disk store: TOML for policies, JSON for state. Both written
+/// atomically with `0600` permissions.
+pub struct FilePolicyStore {
+    policies_path: PathBuf,
+    state_path: PathBuf,
+}
+
+impl FilePolicyStore {
+    /// Default paths under `~/.config/pay/`.
+    pub fn default_path() -> Self {
+        Self {
+            policies_path: PathBuf::from(shellexpand::tilde(POLICIES_FILE).into_owned()),
+            state_path: PathBuf::from(shellexpand::tilde(STATE_FILE).into_owned()),
+        }
+    }
+
+    /// Explicit paths (used by tests and non-default deployments).
+    pub fn at(policies_path: PathBuf, state_path: PathBuf) -> Self {
+        Self {
+            policies_path,
+            state_path,
+        }
+    }
+
+    pub fn policies_path(&self) -> &PathBuf {
+        &self.policies_path
+    }
+
+    pub fn state_path(&self) -> &PathBuf {
+        &self.state_path
+    }
+}
+
+impl PolicyStore for FilePolicyStore {
+    fn load_policies(&self) -> Result<PoliciesFile> {
+        if !self.policies_path.exists() {
+            return Ok(PoliciesFile::default());
+        }
+        let raw = std::fs::read_to_string(&self.policies_path).map_err(|e| {
+            Error::Config(format!(
+                "Failed to read {}: {e}",
+                self.policies_path.display()
+            ))
+        })?;
+        if raw.trim().is_empty() {
+            return Ok(PoliciesFile::default());
+        }
+        toml::from_str(&raw)
+            .map_err(|e| Error::Config(format!("Invalid {}: {e}", self.policies_path.display())))
+    }
+
+    fn save_policies(&self, file: &PoliciesFile) -> Result<()> {
+        let serialized = toml::to_string_pretty(file)
+            .map_err(|e| Error::Config(format!("TOML serialize: {e}")))?;
+        atomic_write_private(&self.policies_path, serialized.as_bytes())
+    }
+
+    fn load_state(&self) -> Result<PolicyState> {
+        if !self.state_path.exists() {
+            return Ok(PolicyState::default());
+        }
+        let raw = std::fs::read_to_string(&self.state_path).map_err(|e| {
+            Error::Config(format!("Failed to read {}: {e}", self.state_path.display()))
+        })?;
+        if raw.trim().is_empty() {
+            return Ok(PolicyState::default());
+        }
+        serde_json::from_str(&raw)
+            .map_err(|e| Error::Config(format!("Invalid {}: {e}", self.state_path.display())))
+    }
+
+    fn save_state(&self, state: &PolicyState) -> Result<()> {
+        let serialized = serde_json::to_string_pretty(state)
+            .map_err(|e| Error::Config(format!("JSON serialize: {e}")))?;
+        atomic_write_private(&self.state_path, serialized.as_bytes())
+    }
+}
+
+/// Write `data` to `path` atomically (temp file + rename) with `0600`
+/// permissions on Unix. Creates parent directories with `0700`.
+fn atomic_write_private(path: &std::path::Path, data: &[u8]) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        Error::Config(format!("Path {} has no parent dir", path.display()))
+    })?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| Error::Config(format!("Failed to create dir {}: {e}", parent.display())))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+    }
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| Error::Config(format!("Failed to create temp file: {e}")))?;
+    {
+        use std::io::Write;
+        tmp.write_all(data)
+            .map_err(|e| Error::Config(format!("Failed to write temp file: {e}")))?;
+        tmp.flush()
+            .map_err(|e| Error::Config(format!("Failed to flush temp file: {e}")))?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600));
+    }
+
+    tmp.persist(path)
+        .map_err(|e| Error::Config(format!("Failed to rename temp file into place: {e}")))?;
+    Ok(())
+}
+
+/// In-memory store for tests.
+#[derive(Default)]
+pub struct MemoryPolicyStore {
+    policies: RwLock<PoliciesFile>,
+    state: RwLock<PolicyState>,
+}
+
+impl MemoryPolicyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_policies(policies: PoliciesFile) -> Self {
+        Self {
+            policies: RwLock::new(policies),
+            state: RwLock::new(PolicyState::default()),
+        }
+    }
+
+    pub fn snapshot_state(&self) -> PolicyState {
+        self.state.read().unwrap().clone()
+    }
+}
+
+impl PolicyStore for MemoryPolicyStore {
+    fn load_policies(&self) -> Result<PoliciesFile> {
+        Ok(self.policies.read().unwrap().clone())
+    }
+    fn save_policies(&self, file: &PoliciesFile) -> Result<()> {
+        *self.policies.write().unwrap() = file.clone();
+        Ok(())
+    }
+    fn load_state(&self) -> Result<PolicyState> {
+        Ok(self.state.read().unwrap().clone())
+    }
+    fn save_state(&self, state: &PolicyState) -> Result<()> {
+        *self.state.write().unwrap() = state.clone();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::Policy;
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn sample() -> Policy {
+        Policy {
+            name: "test".to_string(),
+            max_per_tx: 100_000,
+            daily_cap: 1_000_000,
+            allowed_recipients: vec!["R1".to_string()],
+            allowed_origins: vec!["api.example.com".to_string()],
+            expires_at: Some(t("2027-01-01T00:00:00Z")),
+            paused: false,
+            created_at: t("2026-01-01T00:00:00Z"),
+        }
+    }
+
+    #[test]
+    fn file_store_roundtrip_policies_and_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FilePolicyStore::at(
+            dir.path().join("policies.toml"),
+            dir.path().join("state.json"),
+        );
+
+        // Empty load returns defaults.
+        assert!(store.load_policies().unwrap().policies.is_empty());
+        assert!(store.load_state().unwrap().per_policy.is_empty());
+
+        // Save and reload policies.
+        let mut policies = PoliciesFile::default();
+        policies.upsert(sample());
+        policies.set_default("test").unwrap();
+        store.save_policies(&policies).unwrap();
+        let reloaded = store.load_policies().unwrap();
+        assert_eq!(reloaded.default.as_deref(), Some("test"));
+        assert_eq!(reloaded.policies.get("test"), policies.policies.get("test"));
+
+        // Save and reload state.
+        let mut state = PolicyState::default();
+        let entry = state.entry_mut("test");
+        entry.spent_today = 250_000;
+        entry.day_reset_ts = Some(t("2026-05-01T00:00:00Z"));
+        store.save_state(&state).unwrap();
+        let reloaded_state = store.load_state().unwrap();
+        assert_eq!(
+            reloaded_state.per_policy.get("test").unwrap().spent_today,
+            250_000
+        );
+    }
+
+    #[test]
+    fn file_store_atomic_write_creates_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a/b/c");
+        let store = FilePolicyStore::at(
+            nested.join("policies.toml"),
+            nested.join("state.json"),
+        );
+
+        store.save_policies(&PoliciesFile::default()).unwrap();
+        assert!(nested.join("policies.toml").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_store_writes_with_0600_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let store = FilePolicyStore::at(
+            dir.path().join("policies.toml"),
+            dir.path().join("state.json"),
+        );
+        store.save_policies(&PoliciesFile::default()).unwrap();
+        let mode = std::fs::metadata(dir.path().join("policies.toml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn memory_store_roundtrip() {
+        let store = MemoryPolicyStore::new();
+        let mut policies = PoliciesFile::default();
+        policies.upsert(sample());
+        store.save_policies(&policies).unwrap();
+        assert_eq!(
+            store
+                .load_policies()
+                .unwrap()
+                .policies
+                .keys()
+                .collect::<Vec<_>>(),
+            vec![&"test".to_string()]
+        );
+    }
+}

--- a/rust/crates/core/src/signer.rs
+++ b/rust/crates/core/src/signer.rs
@@ -648,6 +648,7 @@ mod tests {
             path: None,
             secret_key_b58: Some(bs58::encode(&full).into_string()),
             created_at: Some("2026-04-10T00:00:00Z".to_string()),
+            policy: None,
         }
     }
 
@@ -818,6 +819,7 @@ mod tests {
             account: None,
             secret_key_b58: None,
             created_at: None,
+            policy: None,
         };
 
         let err = signer_from_ephemeral(&account).unwrap_err();

--- a/rust/crates/core/tests/session_surfpool_sdk_tests.rs
+++ b/rust/crates/core/tests/session_surfpool_sdk_tests.rs
@@ -266,6 +266,7 @@ fn memory_store_for_keypair(keypair: &Keypair) -> MemoryAccountsStore {
             path: None,
             secret_key_b58: Some(bs58::encode(keypair.to_bytes()).into_string()),
             created_at: Some("2026-04-19T00:00:00Z".to_string()),
+            policy: None,
         },
     );
     MemoryAccountsStore::with_file(file)

--- a/rust/crates/core/tests/surfpool_tests.rs
+++ b/rust/crates/core/tests/surfpool_tests.rs
@@ -1336,12 +1336,13 @@ async fn mpp_build_credential_with_surfnet() {
                 path: None,
                 secret_key_b58: Some(bs58::encode(&payer_bytes).into_string()),
                 created_at: Some("2026-04-10T00:00:00Z".to_string()),
+                policy: None,
             },
         );
         let store = pay_core::accounts::MemoryAccountsStore::with_file(file);
 
         let result =
-            client::mpp::build_credential(&challenge_clone, &store, Some("localnet"), None, None);
+            client::mpp::build_credential(&challenge_clone, &store, Some("localnet"), None, None, None);
         unsafe { std::env::remove_var("PAY_RPC_URL") };
         result
     })

--- a/rust/crates/mcp/Cargo.toml
+++ b/rust/crates/mcp/Cargo.toml
@@ -9,6 +9,7 @@ pay-core = { workspace = true }
 pay-types = { workspace = true }
 pay-keystore = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true }
 crc32fast = { workspace = true }
 flate2 = { workspace = true }
 mime_guess = { workspace = true }

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -200,6 +200,10 @@ fn do_paid_fetch(
     body: Option<String>,
 ) -> Result<PaidFetchResult, pay_core::Error> {
     use pay_core::client::runner::RunOutcome;
+    use pay_core::policy::{
+        FilePolicyStore, PolicyContext, PolicyStore, record_payment_with_store,
+        resolve_active_policy,
+    };
 
     pay_core::skills::validate_cached_catalog_request(method, url, body.as_deref())?;
 
@@ -208,6 +212,30 @@ fn do_paid_fetch(
     let store = pay_core::accounts::FileAccountsStore::default_path();
     let network_override = std::env::var("PAY_NETWORK_ENFORCED").ok();
     let account_override = std::env::var("PAY_ACTIVE_ACCOUNT").ok();
+
+    // Policy resolution: per call so `pay policy update` mid-session takes
+    // effect immediately.
+    let policy_store = FilePolicyStore::default_path();
+    let cli_policy = std::env::var("PAY_POLICY").ok();
+    let account_policy_name = network_override.as_deref().and_then(|net| {
+        let file = pay_core::accounts::AccountsFile::load().ok()?;
+        let acct = if let Some(name) = account_override.as_deref() {
+            file.named_account_for_network(net, name)?
+        } else {
+            file.account_for_network(net)?.1
+        };
+        acct.policy.clone()
+    });
+    let policies = policy_store.load_policies()?;
+    let resolved_policy = resolve_active_policy(
+        cli_policy.as_deref(),
+        account_policy_name.as_deref(),
+        &policies,
+    )?;
+    let policy_ctx = resolved_policy.as_ref().map(|p| PolicyContext {
+        policy: p.clone(),
+        store: &policy_store,
+    });
 
     match outcome {
         RunOutcome::MppChallenge {
@@ -231,23 +259,41 @@ fn do_paid_fetch(
                 network_override.as_deref(),
                 account_override.as_deref(),
                 Some(url),
+                policy_ctx.as_ref(),
             )?;
+            // Capture amount for post-success policy recording. Uses the
+            // pay-core helper so MCP doesn't need to depend on solana-mpp.
+            let amount_for_record = if policy_ctx.is_some() {
+                Some(pay_core::client::mpp::amount_micro_usdc_from_challenge(selected)?)
+            } else {
+                None
+            };
             let mut headers = extra_headers.to_vec();
             headers.push(("Authorization".to_string(), auth_header));
-            interpret_retry(pay_core::client::fetch::fetch_request(
+            let result = interpret_retry(pay_core::client::fetch::fetch_request(
                 method,
                 url,
                 &headers,
                 body.as_deref(),
-            )?)
+            )?)?;
+            if let (Some(ctx), Some(amt)) = (&policy_ctx, amount_for_record) {
+                record_payment_with_store(ctx, amt, chrono::Utc::now())?;
+            }
+            Ok(result)
         }
         RunOutcome::X402Challenge { challenge, .. } => {
+            let amount_for_record = if policy_ctx.is_some() {
+                Some(pay_core::client::x402::amount_micro_usdc_from_challenge(&challenge)?)
+            } else {
+                None
+            };
             let built_payment = pay_core::client::x402::build_payment(
                 &challenge,
                 &store,
                 network_override.as_deref(),
                 account_override.as_deref(),
                 Some(url),
+                policy_ctx.as_ref(),
             )?;
             let mut headers = extra_headers.to_vec();
             headers.extend(
@@ -256,20 +302,27 @@ fn do_paid_fetch(
                     .into_iter()
                     .map(|(name, value)| (name.to_string(), value)),
             );
-            interpret_retry(pay_core::client::fetch::fetch_request(
+            let result = interpret_retry(pay_core::client::fetch::fetch_request(
                 method,
                 url,
                 &headers,
                 body.as_deref(),
-            )?)
+            )?)?;
+            if let (Some(ctx), Some(amt)) = (&policy_ctx, amount_for_record) {
+                record_payment_with_store(ctx, amt, chrono::Utc::now())?;
+            }
+            Ok(result)
         }
         RunOutcome::X402SignInChallenge { challenge, .. } => {
+            // SIWX is a sign-in flow; no on-chain payment, no policy
+            // gate / record.
             let built_payment = pay_core::client::x402::build_siwx_auth_header(
                 &challenge,
                 &store,
                 network_override.as_deref(),
                 account_override.as_deref(),
                 Some(url),
+                None,
             )?;
             let mut headers = extra_headers.to_vec();
             headers.extend(


### PR DESCRIPTION

  Adds named spending policies that the CLI enforces before signing any 402
  challenge. A policy bundles a per-tx cap, a daily cap, an optional
  recipient/origin allowlist, an expiry, and a pause kill switch. The gate
  runs before the keystore is touched, so a rejected request never triggers
  Touch ID and nothing leaves the machine.

  This is the SDK-level companion to the existing --yolo-upto flag: same
  idea (cap what gets paid out), but persistent across invocations and
  richer.

  What's new

  - New module pay_core::policy (config.rs, state.rs, check.rs, store.rs) —
  types, pure check function, file-backed store with atomic writes (0600).
  - New CLI subcommand suite under pay policy: create, list, status, pause,
  resume, update, delete, use.
  - New global --policy <NAME> flag and a per-account policy: field on
  accounts.yml.
  - Hooks in mpp::build_credential and x402::build_payment that take an
  optional PolicyContext and run the gate before signer load.
  - Helpers pay_core::client::{mpp,x402}::amount_micro_usdc_from_challenge
  so MCP can record spend without a direct solana-mpp dep.

  Storage

  - ~/.config/pay/policies.toml — user-edited policy definitions plus an
  optional default.
  - ~/.config/pay/policy-state.json — rolling per-policy spent_today (atomic
   writes via tempfile + rename).

  Resolution order

  --policy <name> flag → account binding → policies.default → no
  enforcement.

  Composes with existing gates

  - --yolo-upto per-invocation cap still runs alongside; stricter wins.
  - auth_required: true accounts still hit Touch ID after the policy passes.
   Policies are most useful for auth_required: false agent-style accounts
  where Touch ID is off.

  Test plan

  - 24 new unit tests in pay_core::policy covering pause, expiry, per-tx
  cap, daily cap + 24h reset, allowlist hit/miss, OR semantics across
  recipient/origin lists, atomic file writes (0600 perms), TOML/JSON
  round-trips, and resolver priority.
  - End-to-end manual run against the public Surfpool sandbox
  (https://debugger.pay.sh/mpp/quote/AAPL) verifying happy path, daily cap
  rejection at exactly the expected boundary, pause kill switch, per-tx
  rejection, origin allowlist miss, and 24h roll on the next paid request.
  - Full workspace cargo build, cargo clippy --workspace --all-targets -- -D
   warnings, and cargo test --workspace all clean.