### PR TITLE
Update MPP link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pay --sandbox curl https://debugger.pay.sh/mpp/quote/AAPL
 Wrap your CLI (`curl`, `claude`, `codex`, etc.) -- when an API returns 402, `pay` detects the payment protocol, prepares the stablecoin transaction, asks the local wallet to authorize and sign it, then retries with the payment proof.
 
 Supports both live payment standards on Solana:
-- **[MPP](https://paymentauth.org/draft-solana-charge-00.html/)** — Machine Payments Protocol
+- **[MPP](https://mpp.dev/)** — Machine Payments Protocol
 - **[x402](https://x402.org/)** — x402 Payment Protocol
 
 Stablecoins deployed to Solana are supported out of the box.


### PR DESCRIPTION
The MPP link in the readme was a 404

I took a guess that it should be mpp.dev to mirror x402.org

If you want to keep it as the solana-specific paymentauth.org link instead, it looks like they dropped the html pages and we can choose any format of https://paymentauth.org/draft-solana-charge-00.{txt, pdf, xml}. LMK if we should change to the txt/pdf instead. 