### PR TITLE
feat: add pay sign command and MCP transaction signing

### DIFF
--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -2,7 +2,7 @@ use std::process::{Command, Stdio};
 
 use clap::Args;
 
-const ALLOWED_TOOLS: &str = "mcp__pay__curl,mcp__pay__search_catalog,mcp__pay__list_catalog,mcp__pay__get_catalog_entry,mcp__pay__get_balance,mcp__pay__topup,mcp__pay__create_skill";
+const ALLOWED_TOOLS: &str = "mcp__pay__curl,mcp__pay__search_catalog,mcp__pay__list_catalog,mcp__pay__get_catalog_entry,mcp__pay__get_balance,mcp__pay__sign_transaction,mcp__pay__topup,mcp__pay__create_skill";
 
 /// Run Claude Code with 402 payment support.
 ///
@@ -149,6 +149,7 @@ mod tests {
             "mcp__pay__list_catalog",
             "mcp__pay__get_catalog_entry",
             "mcp__pay__get_balance",
+            "mcp__pay__sign_transaction",
             "mcp__pay__topup",
             "mcp__pay__create_skill",
         ] {

--- a/rust/crates/cli/src/commands/codex.rs
+++ b/rust/crates/cli/src/commands/codex.rs
@@ -11,6 +11,7 @@ pub(crate) const PAY_MCP_ENABLED_TOOLS: &[&str] = &[
     "list_catalog",
     "get_catalog_entry",
     "get_balance",
+    "sign_transaction",
     "topup",
     "create_skill",
 ];
@@ -237,7 +238,7 @@ mod tests {
 
         assert!(args.contains(&r#"mcp_servers.pay.command="C:\\Users\\me\\pay.exe""#.to_string()));
         assert!(args.contains(
-            &r#"mcp_servers.pay.enabled_tools=["curl","search_catalog","list_catalog","get_catalog_entry","get_balance","topup","create_skill"]"#.to_string()
+            &r#"mcp_servers.pay.enabled_tools=["curl","search_catalog","list_catalog","get_catalog_entry","get_balance","sign_transaction","topup","create_skill"]"#.to_string()
         ));
         assert!(
             args.contains(&r#"mcp_servers.pay.env={PAY_ACTIVE_ACCOUNT="default"}"#.to_string())

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod http;
 pub mod send;
 pub mod server;
 pub mod setup;
+pub mod sign;
 pub mod skills;
 pub mod topup;
 pub mod wget;
@@ -54,6 +55,8 @@ pub enum Command {
     /// Send stablecoins to a recipient address.
     #[command(alias = "push")]
     Send(send::SendCommand),
+    /// Sign and submit a base64-encoded Solana transaction.
+    Sign(sign::SignCommand),
     /// Generate a keypair, store it, and fund your account.
     Setup(setup::SetupCommand),
     /// Import funds from Venmo, PayPal, or a mobile wallet.
@@ -118,6 +121,7 @@ impl Command {
             | Command::Claude(_)
             | Command::Codex(_)
             | Command::Send(_)
+            | Command::Sign(_)
             | Command::Topup(_) => true,
             Command::Setup(_)
             | Command::Account { .. }
@@ -146,6 +150,7 @@ impl Command {
             | Command::Catalog { .. }
             | Command::Install(_)
             | Command::Send(_)
+            | Command::Sign(_)
             | Command::Setup(_)
             | Command::Topup(_)
             | Command::Server { .. } => ToolKind::Mcp,
@@ -191,6 +196,7 @@ impl Command {
             Command::Send(cmd) => {
                 return cmd.run(network_override, account_override, verbose);
             }
+            Command::Sign(cmd) => return cmd.run(network_override, account_override),
             Command::Setup(cmd) => return cmd.run(),
             Command::Topup(cmd) => return cmd.run(),
             Command::Server { command } => return command.run(keypair_override, sandbox),

--- a/rust/crates/cli/src/commands/sign.rs
+++ b/rust/crates/cli/src/commands/sign.rs
@@ -1,0 +1,32 @@
+//! `pay sign` -- sign and submit a Solana transaction.
+
+/// Sign and submit a base64-encoded Solana transaction.
+///
+/// Examples:
+///   pay sign <base64-transaction>
+///   pay --sandbox sign <base64-transaction>
+///   pay --account ludo sign <base64-transaction>
+#[derive(clap::Args)]
+pub struct SignCommand {
+    /// Base64-encoded legacy or v0 Solana transaction.
+    #[arg(value_name = "BASE64_TX")]
+    pub transaction: String,
+}
+
+impl SignCommand {
+    pub fn run(
+        self,
+        network_override: Option<&str>,
+        account_override: Option<&str>,
+    ) -> pay_core::Result<()> {
+        let network = network_override.unwrap_or(pay_core::accounts::MAINNET_NETWORK);
+        let signature = pay_core::sign::sign_and_submit_base64_transaction(
+            &self.transaction,
+            network,
+            account_override,
+        )?;
+
+        println!("{signature}");
+        Ok(())
+    }
+}

--- a/rust/crates/cli/src/components/help.rs
+++ b/rust/crates/cli/src/components/help.rs
@@ -10,7 +10,7 @@ pub const SUPPORTED_PASS_THROUGH_COMMANDS: &[&str] =
     &["curl", "wget", "http", "claude", "codex", "whoami"];
 pub const DEVELOPER_COMMANDS: &[&str] = &["server", "catalog"];
 pub const AGENT_COMMANDS: &[&str] = &["mcp", "skills"];
-pub const ACCOUNT_MANAGEMENT_COMMANDS: &[&str] = &["topup", "account", "setup", "send"];
+pub const ACCOUNT_MANAGEMENT_COMMANDS: &[&str] = &["topup", "account", "setup", "send", "sign"];
 pub const OTHER_COMMANDS: &[&str] = &["fetch", "install"];
 
 pub const ROOT_COMMAND_SUMMARY: &str = "\
@@ -30,4 +30,5 @@ Account management:
   \x1b[1maccount\x1b[0m: Manage accounts (new, import, list, default, remove, export)
   \x1b[1msetup\x1b[0m:   Generate a keypair, store it, and fund your account
   \x1b[1msend\x1b[0m:    Send stablecoins to a recipient address
+  \x1b[1msign\x1b[0m:    Sign and submit a base64-encoded Solana transaction
 ";

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -216,6 +216,7 @@ fn main() {
                 | Command::Catalog { .. }
                 | Command::Install(_)
                 | Command::Send(_)
+                | Command::Sign(_)
                 | Command::Claude(_)
                 | Command::Codex(_)
                 | Command::Curl(_)
@@ -496,6 +497,24 @@ mod tests {
             }
             _ => panic!("expected send command"),
         }
+    }
+
+    #[test]
+    fn sign_command_parses_base64_transaction_arg() {
+        let opts = Opts::try_parse_from(["pay", "sign", "dHg="]).unwrap();
+
+        match opts.command {
+            Some(Command::Sign(cmd)) => assert_eq!(cmd.transaction, "dHg="),
+            _ => panic!("expected sign command"),
+        }
+    }
+
+    #[test]
+    fn command_catalog_includes_sign_command() {
+        let catalog = commands::help::command_catalog(&Opts::command());
+        let commands = catalog["flat_commands"].as_array().unwrap();
+
+        assert!(commands.iter().any(|command| command == "pay sign"));
     }
 
     #[test]

--- a/rust/crates/core/src/client/mod.rs
+++ b/rust/crates/core/src/client/mod.rs
@@ -6,4 +6,5 @@ pub mod runner;
 pub mod sandbox;
 pub mod send;
 pub mod session;
+pub mod sign;
 pub mod x402;

--- a/rust/crates/core/src/client/sign.rs
+++ b/rust/crates/core/src/client/sign.rs
@@ -1,0 +1,359 @@
+//! Sign and submit Solana transactions supplied as base64.
+
+use base64::Engine;
+use solana_mpp::solana_keychain::SolanaSigner;
+use solana_signature::Signature;
+use solana_transaction::{Transaction, versioned::VersionedTransaction};
+
+use crate::{Error, Result};
+
+/// Production entrypoint for `pay sign`.
+pub fn sign_and_submit_base64_transaction(
+    transaction_base64: &str,
+    network: &str,
+    account_override: Option<&str>,
+) -> Result<String> {
+    let store = crate::accounts::FileAccountsStore::default_path();
+    let intent = crate::keystore::AuthIntent::use_account("sign and submit a Solana transaction");
+    let (signer, _) = crate::signer::load_signer_for_network_with_intent(
+        network,
+        &store,
+        account_override,
+        &intent,
+    )?;
+    let rpc_url = std::env::var("PAY_RPC_URL")
+        .unwrap_or_else(|_| solana_mpp::protocol::solana::default_rpc_url(network).to_string());
+    let submitter = RpcTransactionSubmitter { rpc_url };
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| Error::Config(format!("Failed to create signing runtime: {e}")))?;
+
+    rt.block_on(sign_and_submit_with_submitter(
+        transaction_base64,
+        &signer,
+        &submitter,
+    ))
+}
+
+trait TransactionSubmitter {
+    fn submit(&self, transaction: &VersionedTransaction) -> Result<String>;
+}
+
+struct RpcTransactionSubmitter {
+    rpc_url: String,
+}
+
+impl TransactionSubmitter for RpcTransactionSubmitter {
+    fn submit(&self, transaction: &VersionedTransaction) -> Result<String> {
+        use solana_mpp::solana_rpc_client::rpc_client::RpcClient;
+
+        RpcClient::new(self.rpc_url.clone())
+            .send_and_confirm_transaction(transaction)
+            .map(|signature| signature.to_string())
+            .map_err(|e| Error::Mpp(format!("transaction submission failed: {e}")))
+    }
+}
+
+async fn sign_and_submit_with_submitter(
+    transaction_base64: &str,
+    signer: &dyn SolanaSigner,
+    submitter: &dyn TransactionSubmitter,
+) -> Result<String> {
+    let transaction = decode_base64_transaction(transaction_base64)?;
+    let transaction = sign_transaction(transaction, signer).await?;
+    submitter.submit(&transaction)
+}
+
+fn decode_base64_transaction(transaction_base64: &str) -> Result<VersionedTransaction> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(transaction_base64)
+        .map_err(|e| Error::Config(format!("Invalid base64 Solana transaction: {e}")))?;
+
+    match bincode::deserialize::<Transaction>(&bytes) {
+        Ok(transaction) => Ok(VersionedTransaction::from(transaction)),
+        Err(legacy_error) => {
+            bincode::deserialize::<VersionedTransaction>(&bytes).map_err(|versioned_error| {
+                Error::Config(format!(
+                    "Invalid Solana transaction bytes: legacy decode failed ({legacy_error}); \
+                     versioned decode failed ({versioned_error})"
+                ))
+            })
+        }
+    }
+}
+
+async fn sign_transaction(
+    mut transaction: VersionedTransaction,
+    signer: &dyn SolanaSigner,
+) -> Result<VersionedTransaction> {
+    transaction
+        .sanitize()
+        .map_err(|e| Error::Config(format!("Invalid Solana transaction: {e}")))?;
+
+    let signer_pubkey = signer.pubkey();
+    let required_signatures = usize::from(transaction.message.header().num_required_signatures);
+    let required_signer_keys = transaction
+        .message
+        .static_account_keys()
+        .get(..required_signatures)
+        .ok_or_else(|| {
+            Error::Config(
+                "Invalid Solana transaction: required signer keys are missing".to_string(),
+            )
+        })?;
+    let signature_index = required_signer_keys
+        .iter()
+        .position(|pubkey| pubkey == &signer_pubkey)
+        .ok_or_else(|| {
+            Error::Config(format!(
+                "Selected pay account `{signer_pubkey}` is not a required signer for this transaction"
+            ))
+        })?;
+
+    let signature_bytes = signer
+        .sign_message(&transaction.message.serialize())
+        .await
+        .map_err(|e| Error::Mpp(format!("transaction signing failed: {e}")))?;
+    transaction.signatures[signature_index] = Signature::from(<[u8; 64]>::from(signature_bytes));
+
+    Ok(transaction)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    use solana_hash::Hash;
+    use solana_instruction::{AccountMeta, Instruction};
+    use solana_message::{Message, VersionedMessage, v0};
+    use solana_mpp::solana_keychain::MemorySigner;
+    use solana_pubkey::Pubkey;
+
+    const TEST_SIGNATURE: &str =
+        "2ZpY3vMZ7qQX3sRzWpe4bFzgXpaT7HbFoR4ZeYqgZcK8BBcrXWUzj2KCQh1qQdnRuy5uXWgqN65YQHT7ycs44Dq";
+
+    struct FakeSubmitter {
+        result: Result<String>,
+        submitted: Mutex<Vec<VersionedTransaction>>,
+    }
+
+    impl FakeSubmitter {
+        fn succeeds() -> Self {
+            Self {
+                result: Ok(TEST_SIGNATURE.to_string()),
+                submitted: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn fails() -> Self {
+            Self {
+                result: Err(Error::Mpp("fake RPC failure".to_string())),
+                submitted: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn submitted(&self) -> Vec<VersionedTransaction> {
+            self.submitted.lock().unwrap().clone()
+        }
+    }
+
+    impl TransactionSubmitter for FakeSubmitter {
+        fn submit(&self, transaction: &VersionedTransaction) -> Result<String> {
+            self.submitted.lock().unwrap().push(transaction.clone());
+            match &self.result {
+                Ok(signature) => Ok(signature.clone()),
+                Err(error) => Err(Error::Mpp(error.to_string())),
+            }
+        }
+    }
+
+    #[test]
+    fn signs_and_submits_legacy_base64_transaction() {
+        let signer = test_signer(1);
+        let submitter = FakeSubmitter::succeeds();
+        let transaction = legacy_transaction(&signer.pubkey(), &[]);
+
+        let signature = block_on(sign_and_submit_with_submitter(
+            &encode(&transaction),
+            &signer,
+            &submitter,
+        ))
+        .unwrap();
+
+        assert_eq!(signature, TEST_SIGNATURE);
+        let submitted = submitter.submitted();
+        assert_eq!(submitted.len(), 1);
+        assert_ne!(submitted[0].signatures[0], Signature::default());
+    }
+
+    #[test]
+    fn signs_and_submits_v0_base64_transaction() {
+        let signer = test_signer(2);
+        let submitter = FakeSubmitter::succeeds();
+        let transaction = v0_transaction(&signer.pubkey(), &[]);
+
+        let signature = block_on(sign_and_submit_with_submitter(
+            &encode(&transaction),
+            &signer,
+            &submitter,
+        ))
+        .unwrap();
+
+        assert_eq!(signature, TEST_SIGNATURE);
+        let submitted = submitter.submitted();
+        assert!(matches!(submitted[0].message, VersionedMessage::V0(_)));
+        assert_ne!(submitted[0].signatures[0], Signature::default());
+    }
+
+    #[test]
+    fn preserves_existing_signatures_outside_pay_signer_slot() {
+        let signer = test_signer(3);
+        let co_signer = test_signer(4);
+        let existing_signature = Signature::from([9; 64]);
+        let mut transaction = legacy_transaction(
+            &signer.pubkey(),
+            &[AccountMeta::new(co_signer.pubkey(), true)],
+        );
+        transaction.signatures[1] = existing_signature;
+        let submitter = FakeSubmitter::succeeds();
+
+        block_on(sign_and_submit_with_submitter(
+            &encode(&transaction),
+            &signer,
+            &submitter,
+        ))
+        .unwrap();
+
+        let submitted = submitter.submitted();
+        assert_ne!(submitted[0].signatures[0], Signature::default());
+        assert_eq!(submitted[0].signatures[1], existing_signature);
+    }
+
+    #[test]
+    fn rejects_account_not_required_by_transaction() {
+        let signer = test_signer(5);
+        let other_signer = test_signer(6);
+        let submitter = FakeSubmitter::succeeds();
+        let transaction = legacy_transaction(&other_signer.pubkey(), &[]);
+
+        let error = block_on(sign_and_submit_with_submitter(
+            &encode(&transaction),
+            &signer,
+            &submitter,
+        ))
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("not a required signer"));
+        assert!(submitter.submitted().is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_base64_before_submit() {
+        let signer = test_signer(7);
+        let submitter = FakeSubmitter::succeeds();
+
+        let error = block_on(sign_and_submit_with_submitter(
+            "not-base64",
+            &signer,
+            &submitter,
+        ))
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Invalid base64 Solana transaction"));
+        assert!(submitter.submitted().is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_transaction_bytes_before_submit() {
+        let signer = test_signer(8);
+        let submitter = FakeSubmitter::succeeds();
+        let payload = base64::engine::general_purpose::STANDARD.encode([1, 2, 3]);
+
+        let error = block_on(sign_and_submit_with_submitter(
+            &payload, &signer, &submitter,
+        ))
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Invalid Solana transaction bytes"));
+        assert!(submitter.submitted().is_empty());
+    }
+
+    #[test]
+    fn propagates_submit_failure() {
+        let signer = test_signer(9);
+        let submitter = FakeSubmitter::fails();
+        let transaction = legacy_transaction(&signer.pubkey(), &[]);
+
+        let error = block_on(sign_and_submit_with_submitter(
+            &encode(&transaction),
+            &signer,
+            &submitter,
+        ))
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("fake RPC failure"));
+        assert_eq!(submitter.submitted().len(), 1);
+    }
+
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    fn test_signer(seed: u8) -> MemorySigner {
+        let secret = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let public = secret.verifying_key();
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(&secret.to_bytes());
+        bytes.extend_from_slice(public.as_bytes());
+        MemorySigner::from_bytes(&bytes).unwrap()
+    }
+
+    fn instruction(accounts: &[AccountMeta]) -> Instruction {
+        Instruction {
+            program_id: Pubkey::new_from_array([11; 32]),
+            accounts: accounts.to_vec(),
+            data: vec![1, 2, 3],
+        }
+    }
+
+    fn legacy_transaction(payer: &Pubkey, accounts: &[AccountMeta]) -> Transaction {
+        let message = Message::new_with_blockhash(
+            &[instruction(accounts)],
+            Some(payer),
+            &Hash::new_from_array([12; 32]),
+        );
+        Transaction::new_unsigned(message)
+    }
+
+    fn v0_transaction(payer: &Pubkey, accounts: &[AccountMeta]) -> VersionedTransaction {
+        let message = v0::Message::try_compile(
+            payer,
+            &[instruction(accounts)],
+            &[],
+            Hash::new_from_array([13; 32]),
+        )
+        .unwrap();
+        VersionedTransaction {
+            signatures: vec![
+                Signature::default();
+                usize::from(message.header.num_required_signatures)
+            ],
+            message: VersionedMessage::V0(message),
+        }
+    }
+
+    fn encode<T: serde::Serialize>(transaction: &T) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bincode::serialize(transaction).unwrap())
+    }
+}

--- a/rust/crates/core/src/client/sign.rs
+++ b/rust/crates/core/src/client/sign.rs
@@ -24,16 +24,20 @@ pub fn sign_and_submit_base64_transaction(
     let rpc_url = std::env::var("PAY_RPC_URL")
         .unwrap_or_else(|_| solana_mpp::protocol::solana::default_rpc_url(network).to_string());
     let submitter = RpcTransactionSubmitter { rpc_url };
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| Error::Config(format!("Failed to create signing runtime: {e}")))?;
+    let rt = signing_runtime()?;
 
     rt.block_on(sign_and_submit_with_submitter(
         transaction_base64,
         &signer,
         &submitter,
     ))
+}
+
+fn signing_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| Error::Config(format!("Failed to create signing runtime: {e}")))
 }
 
 trait TransactionSubmitter {
@@ -300,6 +304,18 @@ mod tests {
 
         assert!(error.contains("fake RPC failure"));
         assert_eq!(submitter.submitted().len(), 1);
+    }
+
+    #[test]
+    fn signing_runtime_supports_blocking_rpc_client() {
+        let rt = signing_runtime().unwrap();
+
+        rt.block_on(async {
+            assert_eq!(
+                tokio::runtime::Handle::current().runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::MultiThread
+            );
+        });
     }
 
     fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {

--- a/rust/crates/core/src/instructions.md
+++ b/rust/crates/core/src/instructions.md
@@ -12,6 +12,8 @@ Never answer "Can pay do X" from memory; check `list_catalog`.
 - Known provider FQN: call `get_catalog_entry({fqn})`.
 - Known Pay gateway URL, or any URL that returns HTTP 402: call `curl`.
 - Balance or funds question: call `get_balance()`.
+- User provides a base64 Solana transaction and asks Pay to sign and submit it:
+  call `sign_transaction({transaction})`.
 - Top-up, deposit, add funds, or QR code for funding Pay: call `topup`; require
   the user to choose `mobile_wallet` or `onramp`, and require an onramp provider
   when using `onramp`.
@@ -57,5 +59,7 @@ ad-hoc page scraping.
   custodial credentials.
 - Wallet keys stay in the operating system's secure credential store.
 - Real payments require local user authorization.
+- `sign_transaction` broadcasts the provided Solana transaction after local
+  account authorization; use it only when the user asked to sign and submit it.
 - Server-side fee payers handle network fees; the Pay account needs supported
   stablecoins such as USDC, USDT, PYUSD, CASH, or USDG.

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -22,6 +22,7 @@ pub use client::runner::{
 pub use client::sandbox;
 pub use client::send;
 pub use client::session;
+pub use client::sign;
 pub use client::x402;
 
 // Server modules (gateway proxy)

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -129,6 +129,24 @@ setup costs. Use this to check available funds before making paid API calls.
     }
 
     #[tool(
+        description = r#"Sign and submit a base64-encoded Solana transaction with a Pay account.
+
+Use this only when the user has provided a serialized base64 transaction and
+asked Pay to sign and submit it. The tool accepts legacy and v0 Solana
+transactions, preserves existing signatures, asks for local account
+authorization, submits the signed transaction to RPC, and returns the confirmed
+Solana transaction signature. It does not sign arbitrary messages or return a
+signed transaction without broadcasting it.
+"#
+    )]
+    async fn sign_transaction(
+        &self,
+        Parameters(params): Parameters<tools::sign_transaction::Params>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        tools::sign_transaction::run(params).await
+    }
+
+    #[tool(
         description = r#"Generate a top-up QR code PNG for the user's Pay account.
 
 Use this when the user asks to top up, fund, add money, deposit stablecoins, or
@@ -216,6 +234,7 @@ mod tests {
         assert!(source.contains("Never answer \"no\" about Pay capabilities"));
         assert!(source.contains("present the catalog grouped"));
         assert!(source.contains("Generate a top-up QR code PNG"));
+        assert!(source.contains("Sign and submit a base64-encoded Solana transaction"));
         assert!(source.contains("must also specify the provider"));
         assert!(source.contains("tie-breaker guidance"));
         assert!(source.contains("local wallet approval"));

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -4,6 +4,9 @@ use rmcp::schemars;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static PAY_CURL_TEMPFILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Params {
@@ -159,19 +162,39 @@ fn is_binary_content_type(mime: &str) -> bool {
 
 fn write_body_to_tempfile(body: &[u8], mime: &str) -> std::io::Result<String> {
     use std::io::Write;
+
     let extension = extension_for_mime(mime);
-    let mut path = std::env::temp_dir();
-    let name = format!(
-        "pay-curl-{}{extension}",
-        std::time::SystemTime::now()
+    let temp_dir = std::env::temp_dir();
+
+    for _ in 0..16 {
+        let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    path.push(name);
-    let mut file = std::fs::File::create(&path)?;
-    file.write_all(body)?;
-    Ok(path.to_string_lossy().into_owned())
+            .unwrap_or(0);
+        let counter = PAY_CURL_TEMPFILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = temp_dir.join(format!(
+            "pay-curl-{}-{timestamp}-{counter}{extension}",
+            std::process::id()
+        ));
+
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut file) => {
+                file.write_all(body)?;
+                return Ok(path.to_string_lossy().into_owned());
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "failed to allocate a unique pay curl tempfile",
+    ))
 }
 
 /// Pick a sensible filename extension for a MIME type using `mime_guess`'s

--- a/rust/crates/mcp/src/tools/mod.rs
+++ b/rust/crates/mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod get_balance;
 pub mod get_catalog_entry;
 pub mod list_catalog;
 pub mod search_catalog;
+pub mod sign_transaction;
 pub mod topup;
 
 pub(crate) fn tool_error(message: impl Into<String>) -> rmcp::model::CallToolResult {

--- a/rust/crates/mcp/src/tools/sign_transaction.rs
+++ b/rust/crates/mcp/src/tools/sign_transaction.rs
@@ -1,0 +1,101 @@
+use rmcp::model::CallToolResult;
+use rmcp::schemars;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct Params {
+    /// Base64-encoded legacy or v0 Solana transaction to sign and submit.
+    #[schemars(
+        description = "Base64-encoded serialized legacy or v0 Solana transaction to sign and submit."
+    )]
+    pub transaction: String,
+    /// Solana network for Pay account selection and RPC defaults. Defaults to mainnet unless the MCP server enforces a network.
+    #[serde(default)]
+    pub network: Option<String>,
+    /// Pay account name. Defaults to the active/default Pay account unless the MCP server enforces an account.
+    #[serde(default)]
+    pub account: Option<String>,
+}
+
+pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
+    let transaction = params.transaction;
+    let network = resolve_network(
+        params.network.as_deref(),
+        std::env::var("PAY_NETWORK_ENFORCED").ok().as_deref(),
+    );
+    let account = resolve_account(
+        params.account.as_deref(),
+        std::env::var("PAY_ACTIVE_ACCOUNT").ok().as_deref(),
+    );
+
+    let result = tokio::task::spawn_blocking(move || {
+        pay_core::sign::sign_and_submit_base64_transaction(
+            &transaction,
+            &network,
+            account.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
+
+    match result {
+        Ok(signature) => Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+            signature,
+        )])),
+        Err(err) => Ok(super::tool_error(format!("Pay sign failed: {err}"))),
+    }
+}
+
+fn resolve_network(requested: Option<&str>, enforced: Option<&str>) -> String {
+    normalize(enforced)
+        .or_else(|| normalize(requested))
+        .unwrap_or_else(|| pay_core::accounts::MAINNET_NETWORK.to_string())
+}
+
+fn resolve_account(requested: Option<&str>, enforced: Option<&str>) -> Option<String> {
+    normalize(enforced).or_else(|| normalize(requested))
+}
+
+fn normalize(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn params_deserialize_minimal() {
+        let params: Params = serde_json::from_str(r#"{"transaction":"dHg="}"#).unwrap();
+
+        assert_eq!(params.transaction, "dHg=");
+        assert!(params.network.is_none());
+        assert!(params.account.is_none());
+    }
+
+    #[test]
+    fn enforced_network_wins_over_requested_network() {
+        assert_eq!(
+            resolve_network(Some("mainnet"), Some("localnet")),
+            "localnet"
+        );
+    }
+
+    #[test]
+    fn requested_network_falls_back_to_mainnet() {
+        assert_eq!(resolve_network(Some(" devnet "), None), "devnet");
+        assert_eq!(resolve_network(Some(" "), None), "mainnet");
+    }
+
+    #[test]
+    fn enforced_account_wins_over_requested_account() {
+        assert_eq!(
+            resolve_account(Some("requested"), Some(" active ")).as_deref(),
+            Some("active")
+        );
+    }
+}


### PR DESCRIPTION
<img width="746" height="370" alt="Screenshot 2026-05-21 at 16 36 35" src="https://github.com/user-attachments/assets/eba95a8d-532c-47a7-a085-7dc2fdd4339f" />

## Summary

Add Solana transaction signing and submission support to Pay through both the CLI and MCP.

## Changes

- add CLI command:

  ```sh
  pay sign <BASE64_TX>
  ```

- add MCP tool:

  ```text
  sign_transaction
  ```

- support base64-encoded legacy and v0 Solana transactions
- sign with the selected Pay account and submit the transaction through RPC
- preserve existing signatures while updating the Pay signer slot
- print or return the confirmed Solana transaction signature on success
- update Pay MCP instructions and Codex/Claude MCP tool allowlists
- add tests for CLI parsing, transaction decode/signing, signer validation, RPC submission behavior, and MCP parameter routing
- make MCP curl binary-response tempfile creation collision-safe under parallel tests

## Why

Pay already manages user accounts and wallet-backed authorization. This adds a direct way for users and agents to sign externally prepared Solana transactions with a Pay account and submit them without exposing private keys.

## CLI

```sh
pay sign <BASE64_TX>
```

The command:

1. decodes a raw base64 Solana transaction
2. accepts legacy and v0 transactions
3. signs the required signer slot for the selected Pay account
4. submits the signed transaction to RPC
5. prints the confirmed transaction signature

## MCP

The new `sign_transaction` tool accepts:

```json
{
  "transaction": "<BASE64_TX>",
  "network": "mainnet",
  "account": "optional-account-name"
}
```

The MCP flow reuses the same core signing and submission logic as the CLI.

It also honors existing MCP routing through:

- `PAY_NETWORK_ENFORCED`
- `PAY_ACTIVE_ACCOUNT`
- `PAY_RPC_URL`

## Safety and errors

The signing flow rejects before RPC submission when:

- the base64 input is invalid
- the transaction bytes cannot be decoded
- the selected Pay account is not a required signer
- the signer slot cannot be resolved

## Out of scope

This PR does not add:

- sign-only output
- arbitrary message signing
- stdin transaction input
- JSON CLI output

## Validation

- `cargo test -p pay-mcp --lib`
- `cargo test -p pay codex`
- `cargo test -p pay allowed_tools`
- `just rs fmt`
- `just rs lint`
- `just rs unit-test`
- `just ci`