### PR TITLE
feat: add agent-auth skill with CAAP/1.0 attestation, SIWS, and TEE reference docs

### DIFF
--- a/skills/agent-auth/SKILL.md
+++ b/skills/agent-auth/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: agent-auth
+description: |
+  Solana-native agent identity and authentication — SIWS (Sign In With Solana), CAAP/1.0 on-chain attestation, Phala TEE confidential compute, Clerk identity bridge, and CLAWD token-gated subscription tiers. Verifiable at proof.t16z.com.
+  SERVICES: agent attestation, SIWS sign-in, DAS NFT verification, SPL token attestation, subscription tier gating, TEE quote generation, Clerk CAAP session bridging, agent identity registration (Metaplex Agent Registry), token launch via Genesis bonding curves.
+  TRIGGERS: "attest my agent", "verify agent identity", "sign in with Solana", "agent auth", "CAAP attestation", "TEE quote", "Phala attestation", "agent NFT verification", "token-gated agent", "agent subscription tier", "Clerk agent auth", "register agent on-chain", "Metaplex agent identity"
+  Start with get_catalog_entry("agent-auth") to retrieve the full protocol document and available endpoints. Use search_catalog when looking for specific attestation or auth capabilities.
+---
+
+`agent-auth` (Clawd Agent Auth) is the on-chain identity and attestation stack for
+Solana-native AI agents. It combines SIWS wallet authentication, Helius DAS NFT
+verification, CLAWD SPL token attestation, Phala Intel TDX TEE quotes, and
+optional Clerk identity bridging — all exposed through the CAAP/1.0 protocol.
+
+Use agent-auth when agents need to prove identity, verify ownership, check
+subscription tiers, or obtain hardware-rooted attestation quotes. Every
+attestation response carries a TDX quote verifiable at
+[proof.t16z.com](https://proof.t16z.com).
+
+Do not attempt to verify agent identity through ad-hoc RPC calls, manual NFT
+checks, or wallet-balance scraping. Use the agent-auth endpoints — they
+handle SIWS, DAS, token attestation, and TEE quoting in one flow.
+
+## Progressive Disclosure
+
+- Read `references/attestation-flow.md` when walking through a CAAP attestation
+  for the first time, setting up SIWS sign-in, understanding the Clerk+TEE bridge,
+  or troubleshooting attestation failures.
+- Read `references/subscription-tiers.md` when checking what tier a CLAWD balance
+  entitles, computing tier progression, gating features by tier, or explaining
+  subscription levels to users.
+
+## Provider Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/caap/discovery` | CAAP/1.0 protocol discovery document |
+| `POST` | `/api/caap/attest` | Full attestation: SIWS + DAS + TEE quote |
+| `GET` | `/api/caap/status/:agentId` | Lightweight verified/unverified status check |
+| `POST` | `/api/siws/challenge` | Generate SIWS sign-in challenge |
+| `POST` | `/api/siws/verify` | Verify SIWS signature + optional CAAP + TEE |
+| `GET` | `/api/tee/report` | Fresh TEE health quote bound to a nonce |
+
+## CAAP/1.0 Protocol
+
+The Clawd Agent Attestation Protocol ties together five verification phases:
+
+1. **SIWS** (Sign In With Solana) — Ed25519 signature over a structured message
+2. **DAS Verification** — Metaplex Agent Registry + Helius `getAssetsByOwner` confirming agent NFT ownership
+3. **SPL Attestation** — CLAWD token account ownership verification
+4. **Subscription Tiers** — Token balance → tier (Free / Bronze 100K / Silver 500K / Gold 1M / Diamond 5M CLAWD)
+5. **Phala TEE Quote** — Intel TDX quote binding the attestation hash to a specific CVM instance
+
+### Attestation Hash
+
+```
+sha256(`${agentId}:${wallet}:${clawdMint}:${timestamp}`)
+```
+
+Embedded in TDX `report_data` so the TEE quote is cryptographically bound to the specific agent.
+
+## Subscription Tiers
+
+| Tier | CLAWD Required | Features |
+|------|----------------|----------|
+| Free | 0 | Basic auth, SIWS sign-in |
+| Bronze | 100,000 | + Agent attestation, peer card |
+| Silver | 500,000 | + Priority verification, history |
+| Gold | 1,000,000 | + Real-time wallet monitoring, webhooks |
+| Diamond | 5,000,000 | + All features, enterprise SLA |
+
+## Clerk Integration
+
+The `clerk-caap` package bridges Clerk session tokens with CAAP/1.0:
+
+```ts
+import { verifyClerkToken, fetchPhalaAttestation } from "@clawd/clerk-caap";
+
+// 1. Verify Clerk session token (relaxing-collie-65)
+const claims = await verifyClerkToken(sessionToken);
+
+// 2. Run CAAP attestation via relay
+const response = await fetch("https://relay.clawd.xyz/api/caap/attest", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${sessionToken}` },
+  body: JSON.stringify({ walletAddress: claims.wallet_address }),
+});
+// → { verified, attestation, tee: { intelQuote, explorerUrl, ... }, tier }
+```
+
+## TEE Attestation Fields
+
+| Field | Description |
+|-------|-------------|
+| `appId` | Phala dstack app ID |
+| `instanceId` | CVM instance ID |
+| `composeHash` | Hash of the docker-compose.yml |
+| `mrAggregated` | Aggregate measurement register |
+| `mrtd` | TDX MRTD measurement |
+| `rtmr0`–`rtmr3` | Runtime measurement registers |
+| `intelQuote` | Raw Intel TDX quote (base64) |
+| `explorerUrl` | proof.t16z.com verification link |
+| `hasTeeEvidence` | Whether quote generation succeeded |
+
+## Spend-Aware Usage
+
+- Use `/api/caap/status/:agentId` for lightweight checks before full attestation.
+- Full `/api/caap/attest` runs SIWS, DAS, token attestation, and TEE quoting — call it only when all phases are needed.
+- The relay bills per-attestation via x402 payment protocol.
+- Include `X-Wallet-Address` header with the Solana address for requests that don't go through Clerk.
+- Treat attestation responses as cryptographically verifiable, not as trust-on-first-use.
+
+## Best Practices
+
+- Verify TEE quotes at [proof.t16z.com](https://proof.t16z.com) before trusting attestations from untrusted relays.
+- Use the discovery document (`GET /api/caap/discovery`) to confirm protocol version and supported capabilities before attestation flow.
+- Agent identity registration (Metaplex Agent Registry) is a separate on-chain transaction — not included in the basic attestation flow.
+- Clerk session tokens are optional; SIWS-only flows work directly with wallet signatures.

--- a/skills/agent-auth/SKILL.md
+++ b/skills/agent-auth/SKILL.md
@@ -76,7 +76,7 @@ The `clerk-caap` package bridges Clerk session tokens with CAAP/1.0:
 ```ts
 import { verifyClerkToken, fetchPhalaAttestation } from "@clawd/clerk-caap";
 
-// 1. Verify Clerk session token (relaxing-collie-65)
+// 1. Verify Clerk session token
 const claims = await verifyClerkToken(sessionToken);
 
 // 2. Run CAAP attestation via relay

--- a/skills/agent-auth/references/attestation-flow.md
+++ b/skills/agent-auth/references/attestation-flow.md
@@ -1,0 +1,155 @@
+# Agent Attestation Flow
+
+Step-by-step guide for running a CAAP/1.0 agent attestation through the relay.
+
+## Prerequisites
+
+- A Solana wallet (keypair or browser extension)
+- A Clerk session token from `relaxing-collie-65.accounts.dev` (optional, for Clerk-bridged flows)
+- The relay URL: `https://relay.clawd.xyz`
+
+## Flow 1: SIWS-Only (No Clerk)
+
+Use this when you have a Solana wallet and want direct attestation without Clerk.
+
+### Step 1: Get SIWS Challenge
+
+```
+POST https://relay.clawd.xyz/api/siws/challenge
+Content-Type: application/json
+
+{
+  "walletAddress": "<your-solana-address>"
+}
+```
+
+Returns a SIWS input with `{ domain, address, statement, uri, version, chainId, nonce, issuedAt }`.
+
+### Step 2: Sign the SIWS Message
+
+Construct the SIWS message from the input fields and sign with the wallet's private key (Ed25519).
+
+```ts
+import { createSIWSMessage } from "better-auth-solana/client";
+
+const message = createSIWSMessage({
+  address: wallet.publicKey.toBase58(),
+  domain: "relay.clawd.xyz",
+  nonce: siwsInput.nonce,
+  statement: "Sign in to Clawd Agent Auth",
+});
+
+const signature = await wallet.signMessage(new TextEncoder().encode(message));
+```
+
+### Step 3: Verify SIWS
+
+```
+POST https://relay.clawd.xyz/api/siws/verify
+Content-Type: application/json
+
+{
+  "message": "<siws-message>",
+  "signature": "<base64-ed25519-signature>",
+  "walletAddress": "<your-solana-address>",
+  "agentId": "<optional-agent-id>"
+}
+```
+
+Returns `{ verified, attestation?, tee?, tier? }`.
+
+## Flow 2: Full CAAP Attestation (With Clerk)
+
+Use this when the agent already has a Clerk session from `relaxing-collie-65.accounts.dev`.
+
+### Step 1: Get Clerk Session Token
+
+```ts
+import { useAuth } from "@clerk/nextjs";
+
+const { getToken } = useAuth();
+const token = await getToken({ template: "solana_wallet" });
+```
+
+The JWT template must include `wallet_address` and `agent_id` from `user.publicMetadata`.
+
+### Step 2: Run Attestation
+
+```
+POST https://relay.clawd.xyz/api/caap/attest
+Authorization: Bearer <clerk-session-token>
+Content-Type: application/json
+
+{
+  "walletAddress": "<your-solana-address>"
+}
+```
+
+Returns:
+```json
+{
+  "verified": true,
+  "attestation": {
+    "agentId": "my-agent",
+    "wallet": "<solana-address>",
+    "clawdMint": "8cHzQHUS2s2h8TzCmfqPKYiM4dSt4roa3n7MyRLApump",
+    "attestationHash": "sha256-hex...",
+    "tokenBalance": 1500000,
+    "agentNftAddress": "<nft-mint>"
+  },
+  "tee": {
+    "intelQuote": "<base64-tdx-quote>",
+    "explorerUrl": "https://proof.t16z.com/?attestation=...",
+    "mrAggregated": "<hex>",
+    "mrtd": "<hex>",
+    "rtmr0": "<hex>",
+    "hasTeeEvidence": true
+  },
+  "tier": {
+    "tier": "gold",
+    "clawdRequired": 1000000,
+    "clawdToNextTier": 3500000,
+    "percentToNext": 70
+  }
+}
+```
+
+## Flow 3: Lightweight Status Check
+
+For quick verified/unverified checks without running the full TEE attestation:
+
+```
+GET https://relay.clawd.xyz/api/caap/status/:agentId
+```
+
+Returns `{ verified: boolean }`. Use this before paying for a full attestation.
+
+## Flow 4: TEE Health Check
+
+Verify the relay's TEE instance is healthy and get a fresh quote:
+
+```
+GET https://relay.clawd.xyz/api/tee/report
+```
+
+Returns a fresh Intel TDX quote bound to the current nonce, verifying that the relay is still running inside a genuine Phala TEE CVM.
+
+## Billing
+
+All attestation endpoints bill per-request via the x402 payment protocol. The relay returns HTTP 402 Payment Required with an x402 challenge. Pay handles the payment flow transparently.
+
+- `/api/caap/status/:agentId` — lowest cost, no TEE quote
+- `/api/caap/attest` — full attestation, highest cost
+- `/api/siws/verify` — medium cost (SIWS + optional TEE)
+- `/api/tee/report` — fresh TEE quote only
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success with attestation payload |
+| 400 | Missing or invalid wallet address / SIWS signature |
+| 401 | Missing or invalid Clerk session token |
+| 402 | Payment required — use `pay curl` to handle automatically |
+| 404 | Agent ID not found (status endpoint) |
+| 500 | Relay internal error or TEE quote generation failure |

--- a/skills/agent-auth/references/attestation-flow.md
+++ b/skills/agent-auth/references/attestation-flow.md
@@ -5,7 +5,7 @@ Step-by-step guide for running a CAAP/1.0 agent attestation through the relay.
 ## Prerequisites
 
 - A Solana wallet (keypair or browser extension)
-- A Clerk session token from `relaxing-collie-65.accounts.dev` (optional, for Clerk-bridged flows)
+- A Clerk session token from `<your-clerk-instance>.accounts.dev` (optional, for Clerk-bridged flows)
 - The relay URL: `https://relay.clawd.xyz`
 
 ## Flow 1: SIWS-Only (No Clerk)
@@ -60,7 +60,7 @@ Returns `{ verified, attestation?, tee?, tier? }`.
 
 ## Flow 2: Full CAAP Attestation (With Clerk)
 
-Use this when the agent already has a Clerk session from `relaxing-collie-65.accounts.dev`.
+Use this when the agent already has a Clerk session from `<your-clerk-instance>.accounts.dev`.
 
 ### Step 1: Get Clerk Session Token
 
@@ -109,7 +109,7 @@ Returns:
     "tier": "gold",
     "clawdRequired": 1000000,
     "clawdToNextTier": 3500000,
-    "percentToNext": 70
+    "percentToNext": 12.5
   }
 }
 ```

--- a/skills/agent-auth/references/subscription-tiers.md
+++ b/skills/agent-auth/references/subscription-tiers.md
@@ -1,0 +1,143 @@
+# Subscription Tiers And Token Gating
+
+How CLAWD token balances map to subscription tiers and unlock agent auth features.
+
+## Tier Thresholds
+
+| Tier | CLAWD Required | Cumulative |
+|------|---------------|------------|
+| Free | 0 | 0 |
+| Bronze | 100,000 | 100,000 |
+| Silver | 500,000 | 500,000 |
+| Gold | 1,000,000 | 1,000,000 |
+| Diamond | 5,000,000 | 5,000,000 |
+
+## Tier Features
+
+### Free (0 CLAWD)
+- Basic SIWS sign-in
+- Discovery endpoint access
+- Cannot run full attestation (status checks only)
+
+### Bronze (100,000 CLAWD)
+- Everything in Free
+- Full CAAP attestation (SIWS + DAS + token attestation)
+- Peer card generation
+- Basic agent profile in directory
+
+### Silver (500,000 CLAWD)
+- Everything in Bronze
+- Priority verification queue
+- Verification history (last 90 days)
+- Multi-agent management (up to 5 agents per wallet)
+
+### Gold (1,000,000 CLAWD)
+- Everything in Silver
+- Real-time wallet monitoring
+- Webhook notifications for attestation events
+- Team accounts (up to 10 members)
+- API rate limit increase
+
+### Diamond (5,000,000 CLAWD)
+- Everything in Gold
+- Dedicated verification node
+- Enterprise SLA (99.9% uptime)
+- White-label attestation domain
+- Custom tier branding
+- Priority support
+
+## Computing Tiers
+
+### From the SDK
+
+```ts
+import { computeTier, TIER_THRESHOLDS } from "@clawd/agent-auth-solana";
+
+const tier = computeTier(clawdBalance);
+
+// tier: {
+//   tier: "gold",           // Tier label
+//   clawdRequired: 1000000,  // CLAWD needed for this tier
+//   nextTier?: {             // Next tier info (undefined for Diamond)
+//     tier: "diamond",
+//     clawdRequired: 5000000,
+//   },
+//   clawdToNextTier?: 4000000, // CLAWD needed to reach next tier (undefined for Diamond)
+//   percentToNext?: 80,        // 0-100 progress to next tier (undefined for Diamond)
+// }
+```
+
+### From the Relay API
+
+The `/api/caap/attest` response includes a `tier` field:
+
+```json
+{
+  "tier": {
+    "tier": "gold",
+    "clawdRequired": 1000000,
+    "clawdToNextTier": 3500000,
+    "percentToNext": 70
+  }
+}
+```
+
+## Token Balance Sources
+
+The relay checks CLAWD balance from two sources:
+
+1. **Primary**: SPL token account on the attestation wallet
+2. **Fallback**: Delegated token accounts (for multi-wallet setups)
+
+Use `fetchWalletSnapshot` for a full balance picture:
+
+```ts
+import { fetchWalletSnapshot } from "@clawd/agent-auth-solana";
+
+const snapshot = await fetchWalletSnapshot(walletAddress, {
+  heliusRpcUrl: `https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}`,
+});
+
+// snapshot: {
+//   walletAddress: string,
+//   solBalance: number,       // SOL in lamports
+//   clawdBalance: number,    // CLAWD raw amount
+//   tokenAccounts: Array<{ mint, balance, decimals }>,
+//   fetchedAt: number,       // Unix timestamp
+// }
+```
+
+## CLAWD Token Details
+
+- **Mint Address**: `8cHzQHUS2s2h8TzCmfqPKYiM4dSt4roa3n7MyRLApump`
+- **Network**: Solana mainnet-beta
+- **Program**: Token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+- **Decimals**: 6
+
+## Tier Gating In Better Auth
+
+When using `createCaapPlugin` with `enableSubscriptionTiers: true`, endpoints are automatically gated:
+
+```ts
+import { createCaapPlugin } from "@clawd/agent-auth-solana";
+
+createCaapPlugin({
+  heliusApiKey: process.env.HELIUS_API_KEY,
+  clawdMint: "8cHzQHUS2s2h8TzCmfqPKYiM4dSt4roa3n7MyRLApump",
+  enableSubscriptionTiers: true,   // Enables automatic tier gating
+  enableDasAttestation: true,      // Enables DAS NFT verification
+});
+```
+
+The plugin enforces:
+- Free tier: `/caap/discovery` only
+- Bronze+: `/caap/attest`, `/caap/status`
+- Silver+: Rate-limited access with history
+- Gold+: Webhook registration, team endpoints
+- Diamond+: All endpoints with elevated limits
+
+## Upgrading Tiers
+
+Tiers are computed dynamically from the on-chain CLAWD balance — no manual upgrade flow needed. Buy CLAWD on any Solana DEX and the next attestation will reflect the new tier.
+
+No SOL is needed for attestation — the relay's server-side fee payer handles transaction costs.

--- a/skills/agent-auth/references/subscription-tiers.md
+++ b/skills/agent-auth/references/subscription-tiers.md
@@ -4,20 +4,20 @@ How CLAWD token balances map to subscription tiers and unlock agent auth feature
 
 ## Tier Thresholds
 
-| Tier | CLAWD Required | Cumulative |
-|------|---------------|------------|
-| Free | 0 | 0 |
-| Bronze | 100,000 | 100,000 |
-| Silver | 500,000 | 500,000 |
-| Gold | 1,000,000 | 1,000,000 |
-| Diamond | 5,000,000 | 5,000,000 |
+| Tier | CLAWD Required |
+|------|---------------|
+| Free | 0 |
+| Bronze | 100,000 |
+| Silver | 500,000 |
+| Gold | 1,000,000 |
+| Diamond | 5,000,000 |
 
 ## Tier Features
 
 ### Free (0 CLAWD)
+- Protocol discovery endpoint access (`/caap/discovery`)
 - Basic SIWS sign-in
-- Discovery endpoint access
-- Cannot run full attestation (status checks only)
+- Status checks and full attestation require Bronze+
 
 ### Bronze (100,000 CLAWD)
 - Everything in Free
@@ -63,7 +63,7 @@ const tier = computeTier(clawdBalance);
 //     clawdRequired: 5000000,
 //   },
 //   clawdToNextTier?: 4000000, // CLAWD needed to reach next tier (undefined for Diamond)
-//   percentToNext?: 80,        // 0-100 progress to next tier (undefined for Diamond)
+//   percentToNext?: 0,         // 0-100 progress to next tier (undefined for Diamond); at exactly 1M CLAWD = Gold minimum, so 0% to Diamond
 // }
 ```
 
@@ -77,7 +77,7 @@ The `/api/caap/attest` response includes a `tier` field:
     "tier": "gold",
     "clawdRequired": 1000000,
     "clawdToNextTier": 3500000,
-    "percentToNext": 70
+    "percentToNext": 12.5
   }
 }
 ```


### PR DESCRIPTION
## Summary

Adds the Clawd Agent Auth skill (`skills/agent-auth/`) to the pay-skills registry, documenting the CAAP/1.0 protocol — a Solana-native agent identity and attestation stack.

## Files Added

- **`skills/agent-auth/SKILL.md`** — Full skill listing with:
  - Frontmatter: name, description, SERVICES, TRIGGERS
  - Provider endpoints table (6 endpoints covering discovery, attestation, status, SIWS, TEE)
  - CAAP/1.0 protocol phases (SIWS, DAS, token attestation, subscription tiers, Phala TDX)
  - Progressive disclosure references to attestation flow and subscription tiers docs
  - Clerk integration code examples
  - TEE attestation field reference
  - Spend-aware usage and best practices

- **`skills/agent-auth/references/attestation-flow.md`** — Step-by-step attestation guide covering all four flows:
  - SIWS-only (no Clerk)
  - Full CAAP attestation (with Clerk)
  - Lightweight status check
  - TEE health check
  - Billing table and error handling reference

- **`skills/agent-auth/references/subscription-tiers.md`** — Token-gated tier documentation:
  - Tier thresholds (Free → Diamond, 0 → 5M CLAWD)
  - Feature breakdown per tier
  - SDK computation (`computeTier`)
  - Relay API response format
  - Token balance sources and tier gating implementation

## Service Details

- **Homepage:** https://pay.sh/services/auth/agent
- **Relay:** https://relay.clawd.xyz
- **TEE Verification:** https://proof.t16z.com
- **Protocol:** CAAP/1.0
- **Network:** Solana mainnet-beta
- **Payment:** x402 protocol (per-attestation billing)

Built by Clawd Labs · Powered by Helius, Metaplex, Clerk, Phala Network, Better Auth