### PR TITLE
ci(npm-publish): bump setup-node to v6 to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,13 +59,13 @@ jobs:
         working-directory: .
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.7
         with:
           version: 10
           run_install: false
@@ -76,7 +76,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('typescript/pnpm-lock.yaml') }}
@@ -217,7 +217,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ github.event.inputs.create-github-release == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Problem

The `@solana/pay` publish run fails at the final step with:

```
npm error 401 Unauthorized - PUT https://registry.npmjs.org/@solana%2fpay
- Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
```

Build, pack, and provenance signing all succeed — only the registry PUT fails. The log also shows `npm warn Unknown user config "always-auth"`.

## Cause

`actions/setup-node@v4` writes a legacy `.npmrc` with `always-auth=true`, which forces credential-based auth. npm then skips the OIDC trusted-publishing exchange and falls back to web auth, which fails since there's no token.

The working `kora` and `keychain` publish workflows use `setup-node@v6` (which no longer writes `always-auth`) and don't hit this.

## Fix

Bump `setup-node` to `@v6` and align the other actions with those workflows:

| Action | Before | After |
|---|---|---|
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/checkout` | `@v4` | `@v6` |
| `pnpm/action-setup` | `@v4` | `@v6.0.7` |
| `actions/cache` | `@v4` | `@v5` |
| `actions/github-script` | `@v7` | `@v9` |