### PR TITLE
feat(server): gcp_metadata_identity — audience-bound OIDC tokens for IAM-locked upstreams

### DIFF
--- a/rust/crates/core/src/server/proxy.rs
+++ b/rust/crates/core/src/server/proxy.rs
@@ -1349,15 +1349,24 @@ async fn fetch_gcp_metadata_token(
 /// user credentials cannot mint identity tokens without service-account
 /// impersonation, so local dev either impersonates out-of-band or uses the
 /// spec's `header` auth mode instead.
+/// Identity-endpoint URL with the audience as a properly encoded query pair —
+/// an audience like `https://svc/path?tenant=a&region=b` must arrive intact,
+/// not truncated at the first `&` (which would mint a wrong-audience token).
+fn gcp_identity_url(audience: &str) -> reqwest::Url {
+    let mut url = reqwest::Url::parse(
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity",
+    )
+    .expect("static metadata URL parses");
+    url.query_pairs_mut().append_pair("audience", audience);
+    url
+}
+
 async fn fetch_gcp_metadata_identity_token(
     client: &reqwest::Client,
     audience: &str,
 ) -> Result<FetchedToken, String> {
-    let url = format!(
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}"
-    );
     let resp = client
-        .get(&url)
+        .get(gcp_identity_url(audience))
         .header("Metadata-Flavor", "Google")
         .timeout(std::time::Duration::from_secs(2))
         .send()
@@ -1419,6 +1428,27 @@ mod tests {
         let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(serde_json::json!({ "aud": "https://svc", "exp": exp }).to_string());
         format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn gcp_identity_url_encodes_audience_with_query_metacharacters() {
+        let url = gcp_identity_url("https://service.example/path?tenant=a&region=b");
+        assert_eq!(
+            url.as_str(),
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https%3A%2F%2Fservice.example%2Fpath%3Ftenant%3Da%26region%3Db"
+        );
+        // the audience round-trips as ONE pair, not a truncated prefix
+        let pairs: Vec<(String, String)> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![(
+                "audience".to_string(),
+                "https://service.example/path?tenant=a&region=b".to_string()
+            )]
+        );
     }
 
     #[test]

--- a/rust/crates/core/src/server/proxy.rs
+++ b/rust/crates/core/src/server/proxy.rs
@@ -305,6 +305,7 @@ pub async fn prepare_upstream(
         }
         Some(AuthConfig::Oauth2 {
             token_url,
+            audience,
             scopes,
             client_id_from_env,
             client_secret_from_env,
@@ -312,6 +313,7 @@ pub async fn prepare_upstream(
         }) => {
             match oauth2_token(
                 token_url,
+                audience.as_deref(),
                 scopes,
                 client_id_from_env.as_deref(),
                 client_secret_from_env.as_deref(),
@@ -1131,6 +1133,9 @@ struct FetchedToken {
 #[derive(PartialEq, Eq, Hash)]
 struct TokenKey {
     token_url: String,
+    /// Identity tokens are audience-bound — two upstreams sharing the
+    /// metadata endpoint must not share a cache slot.
+    audience: Option<String>,
     scopes: Vec<String>,
     client_id: Option<String>,
 }
@@ -1145,12 +1150,14 @@ fn token_cache() -> &'static Arc<RwLock<HashMap<TokenKey, CachedToken>>> {
 /// Fetch an OAuth2 access token, using a cached value if still valid.
 async fn oauth2_token(
     token_url: &str,
+    audience: Option<&str>,
     scopes: &[String],
     client_id_env: Option<&str>,
     client_secret_env: Option<&str>,
 ) -> Result<String, String> {
     let key = TokenKey {
         token_url: token_url.to_string(),
+        audience: audience.map(str::to_string),
         scopes: scopes.to_vec(),
         client_id: client_id_env.and_then(|e| std::env::var(e).ok()),
     };
@@ -1166,7 +1173,14 @@ async fn oauth2_token(
         }
     }
 
-    let fetched = fetch_oauth2_token(token_url, scopes, client_id_env, client_secret_env).await?;
+    let fetched = fetch_oauth2_token(
+        token_url,
+        audience,
+        scopes,
+        client_id_env,
+        client_secret_env,
+    )
+    .await?;
 
     // Refresh 60s before the provider-reported expiry. Providers (especially
     // the GCP metadata server) may return a token that's already partially
@@ -1191,6 +1205,7 @@ async fn oauth2_token(
 
 async fn fetch_oauth2_token(
     token_url: &str,
+    audience: Option<&str>,
     scopes: &[String],
     client_id_env: Option<&str>,
     client_secret_env: Option<&str>,
@@ -1200,6 +1215,12 @@ async fn fetch_oauth2_token(
     // Special: GCP metadata server.
     if token_url == "gcp_metadata" {
         return fetch_gcp_metadata_token(&client, scopes).await;
+    }
+    if token_url == "gcp_metadata_identity" {
+        // Spec validation enforces this; defensive for programmatic callers.
+        let audience = audience
+            .ok_or("token_url \"gcp_metadata_identity\" requires oauth2.audience to be set")?;
+        return fetch_gcp_metadata_identity_token(&client, audience).await;
     }
 
     // Standard OAuth2 client_credentials grant.
@@ -1322,9 +1343,109 @@ async fn fetch_gcp_metadata_token(
     })
 }
 
+/// Fetch an audience-bound OIDC identity token from the GCP metadata server
+/// (Cloud Run / GCE) — what invoking an IAM-locked Cloud Run service needs;
+/// the access-token sibling above cannot open that door. No ADC fallback:
+/// user credentials cannot mint identity tokens without service-account
+/// impersonation, so local dev either impersonates out-of-band or uses the
+/// spec's `header` auth mode instead.
+async fn fetch_gcp_metadata_identity_token(
+    client: &reqwest::Client,
+    audience: &str,
+) -> Result<FetchedToken, String> {
+    let url = format!(
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience={audience}"
+    );
+    let resp = client
+        .get(&url)
+        .header("Metadata-Flavor", "Google")
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+        .map_err(|e| {
+            format!(
+                "GCP metadata server unreachable ({e}) — identity tokens require running on \
+                 GCP (Cloud Run/GCE); for local dev use `auth.method: header` or impersonate \
+                 a service account out-of-band"
+            )
+        })?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "GCP metadata identity endpoint returned {} for audience `{audience}`",
+            resp.status()
+        ));
+    }
+    // The identity endpoint returns the raw JWT as the body, not JSON.
+    let token = resp
+        .text()
+        .await
+        .map_err(|e| format!("reading identity token body: {e}"))?
+        .trim()
+        .to_string();
+
+    // The token carries its own lifetime; honour it instead of assuming 1h.
+    let expires_in_secs = jwt_seconds_until_expiry(&token).unwrap_or(3600);
+    tracing::debug!(audience, "OIDC identity token from GCP metadata server");
+    Ok(FetchedToken {
+        access_token: token,
+        expires_in_secs,
+    })
+}
+
+/// Remaining lifetime of a JWT from its `exp` claim (seconds from now).
+/// `None` when the token does not decode — callers fall back to a
+/// conservative default rather than failing a token that GCP just minted.
+fn jwt_seconds_until_expiry(jwt: &str) -> Option<u64> {
+    let payload_b64 = jwt.split('.').nth(1)?;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    let exp = claims["exp"].as_u64()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    Some(exp.saturating_sub(now))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn jwt_with_exp(exp: serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::json!({ "aud": "https://svc", "exp": exp }).to_string());
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn jwt_expiry_reads_exp_claim_and_degrades_to_none() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let remaining =
+            jwt_seconds_until_expiry(&jwt_with_exp(serde_json::json!(now + 600))).unwrap();
+        assert!((595..=600).contains(&remaining), "got {remaining}");
+
+        // already-expired token clamps to zero rather than underflowing
+        assert_eq!(
+            jwt_seconds_until_expiry(&jwt_with_exp(serde_json::json!(now - 100))),
+            Some(0)
+        );
+
+        // garbage shapes degrade to None (caller falls back to a default)
+        assert_eq!(jwt_seconds_until_expiry("not-a-jwt"), None);
+        assert_eq!(jwt_seconds_until_expiry("a.b.c"), None);
+        assert_eq!(
+            jwt_seconds_until_expiry(&jwt_with_exp(serde_json::json!("soon"))),
+            None
+        );
+    }
     use pay_types::metering::{
         AccessTokenFetchConfig, AccessTokenInjectConfig, AccessTokenResponseConfig,
         HmacCanonicalComponent, HmacCanonicalConfig, HmacDigestAlgorithm, HmacEncoding,
@@ -2563,6 +2684,7 @@ mod tests {
                 url: "https://api.example.com".to_string(),
                 path_rewrites: vec![],
                 auth: Some(Box::new(AuthConfig::Oauth2 {
+                    audience: None,
                     token_url: "https://oauth.example.com/token".to_string(),
                     scopes: vec!["scope-a".to_string()],
                     client_id_from_env: Some("_TEST_MISSING_CLIENT_ID".to_string()),

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -384,7 +384,15 @@ pub enum AuthConfig {
     Oauth2 {
         /// Token endpoint URL (e.g. `https://oauth2.googleapis.com/token`).
         /// Special value `"gcp_metadata"` uses the GCP metadata server.
+        /// Special value `"gcp_metadata_identity"` mints an audience-bound
+        /// OIDC identity token instead of an access token — required for
+        /// invoking IAM-locked Cloud Run services (`audience` must be set).
         token_url: String,
+        /// OIDC audience, exactly the upstream service URL. Required with
+        /// `token_url: "gcp_metadata_identity"`; rejected elsewhere (access
+        /// tokens are not audience-bound).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audience: Option<String>,
         /// OAuth2 scopes to request.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         scopes: Vec<String>,
@@ -1718,6 +1726,25 @@ fn validate_auth_config(auth: &AuthConfig, context: &str, errs: &mut Vec<String>
             fetch,
             inject,
         } => validate_access_token_auth(prepare, fetch, inject, context, errs),
+        AuthConfig::Oauth2 {
+            token_url,
+            audience,
+            ..
+        } => {
+            let is_identity = token_url == "gcp_metadata_identity";
+            match (is_identity, audience) {
+                (true, None) => errs.push(format!(
+                    "{context}: oauth2.token_url \"gcp_metadata_identity\" requires oauth2.audience                      (the IAM-locked upstream service URL the identity token is minted for)"
+                )),
+                (true, Some(audience)) if audience.trim().is_empty() => errs.push(format!(
+                    "{context}: oauth2.audience is empty — set it to the upstream service URL"
+                )),
+                (false, Some(_)) => errs.push(format!(
+                    "{context}: oauth2.audience is only valid with token_url \"gcp_metadata_identity\"                      (access tokens are not audience-bound)"
+                )),
+                _ => {}
+            }
+        }
         _ => {}
     }
 }
@@ -4684,6 +4711,61 @@ endpoints:
             duplicate_errs
                 .iter()
                 .any(|e| e.contains("must set exactly one"))
+        );
+    }
+
+    #[test]
+    fn oauth2_identity_mode_requires_audience_and_rejects_it_elsewhere() {
+        // identity mode without audience: refused, actionably
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity"#,
+        ))
+        .unwrap();
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("requires oauth2.audience")),
+            "{errs:?}"
+        );
+
+        // audience on a non-identity token_url: refused
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: https://oauth2.googleapis.com/token
+    audience: https://svc-hash-uc.a.run.app"#,
+        ))
+        .unwrap();
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("only valid with token_url \"gcp_metadata_identity\"")),
+            "{errs:?}"
+        );
+
+        // the happy pair: identity mode + audience — no oauth2 errors
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity
+    audience: https://svc-hash-uc.a.run.app"#,
+        ))
+        .unwrap();
+        let errs = validate_api_spec(&spec);
+        assert!(
+            !errs.iter().any(|e| e.contains("oauth2")),
+            "identity+audience must validate: {errs:?}"
+        );
+
+        // empty audience: refused
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity
+    audience: " ""#,
+        ))
+        .unwrap();
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("oauth2.audience is empty")),
+            "{errs:?}"
         );
     }
 


### PR DESCRIPTION
Unblocks MPP-gating scale-to-zero micro-agents on Cloud Run (agent-gateway thread in #pay-cli): the existing `gcp_metadata` mode mints **access tokens**; invoking an IAM-locked Cloud Run service needs an **audience-bound OIDC identity token** from the metadata `/identity` endpoint. Without IAM lock the Cloud Run URL is a payment-bypass side door.

- `Oauth2` spec: optional `audience`, new special `token_url: "gcp_metadata_identity"`. Fail-closed validation both directions (identity without audience / audience elsewhere), actionable messages
- fetcher beside the existing one: raw-JWT body, lifetime from the token's own `exp` claim (conservative default when undecodable), 2s metadata timeout
- token cache key now includes audience — no cross-upstream slot sharing
- deliberately no ADC fallback: user creds can't mint identity tokens without impersonation; the error names the local-dev alternatives (`header` auth mode / out-of-band impersonation)

**Test plan**: `cargo test -p pay-core --lib --all-features -- --test-threads=1` → 769 pass (includes new spec-validation matrix + JWT-expiry unit tests); `cargo test -p pay-types --lib` → 147 pass; `cargo clippy --workspace --all-targets` clean. Full parallel workspace runs surface two pre-existing shared-state flakes (`body_to_mcp_content_octet_stream_spills_to_tempfile` tempdir race, `forward_request_injects_hmac_auth` env-var race) — different test each run, each green in isolation and single-threaded, untouched by this diff. Note: `--all-features` clippy also still hits the pre-existing #398 `openapi_resolve_smoke` breakage (fix already staged in the #416 branch).

Live verification needs a GCP runtime (metadata server); the spec-level contract is fully covered. First consumer: the micro-agent proxy YAML drafted in agent-gateway.
