### PR TITLE
feat(mcp): refine capability requests with MRTR

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1259,6 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2451,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -2638,7 +2650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2650,6 +2662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -3235,6 +3248,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -3871,7 +3890,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3879,6 +3898,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hcl-edit"
@@ -6436,7 +6460,7 @@ dependencies = [
  "percent-encoding 2.3.2",
  "rand 0.8.6",
  "reqwest 0.12.28",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yml",
@@ -6505,10 +6529,11 @@ dependencies = [
  "pay-keystore",
  "pay-types",
  "qrcode",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "rmcp",
  "same-file",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yml",
@@ -6813,7 +6838,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.8.26",
  "sfv",
- "socket2 0.4.10",
+ "socket2 0.6.4",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -6895,8 +6920,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f1c33f6ce9ca9b8e81190796f7d4d543d1ab2a310097d884ebe48ce5d33c4d"
 dependencies = [
  "arrayvec",
- "hashbrown 0.13.2",
- "parking_lot 0.11.2",
+ "hashbrown 0.17.1",
+ "parking_lot 0.12.5",
  "rand 0.8.6",
 ]
 
@@ -7250,7 +7275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7878,34 +7903,38 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.9.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa07b85b779d1e1df52dd79f6c6bffbe005b191f07290136cc42a142da3409a"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "chrono",
  "futures 0.3.32",
- "paste",
+ "hmac 0.13.0",
+ "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18",
  "tracing",
+ "url 2.5.8",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.9.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fa09933cac0d0204c8a5d647f558425538ed6a0134b1ebb1ae4dc00c96db3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,7 +44,7 @@ indicatif = "0.17"
 chrono = "0.4"
 
 # MCP
-rmcp = { version = "0.9", features = ["server", "transport-io", "elicitation", "schemars"] }
+rmcp = { version = "3.1", features = ["server", "transport-io", "elicitation", "schemars", "request-state"] }
 schemars = "0.8"
 
 # TUI

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -582,6 +582,7 @@ fn handle_outcome(
             challenge,
             advertised_challenges,
             resource_url,
+            ..
         } => {
             print_verbose_challenges(&advertised_challenges, verbose, is_json);
             let req: Option<SessionRequest> = challenge.request.decode().ok();

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -126,7 +126,7 @@ struct PayerState {
     /// Cached delegated-session authorization. Holding the mutex serializes
     /// requests because the server reserves a session's remaining capacity
     /// while it meters a response.
-    session_authorization: Arc<tokio::sync::Mutex<Option<String>>>,
+    session_authorization: pay_core::session_manager::SessionSlot,
     session_opener: SessionOpener,
     client: reqwest::Client,
     store: Arc<dyn AccountsStore>,
@@ -180,7 +180,7 @@ impl PayerState {
             responses_path: upstream.responses_path.trim_start_matches('/').to_string(),
             require_payment: upstream.require_payment,
             payment_protocol: upstream.payment_protocol,
-            session_authorization: Arc::new(tokio::sync::Mutex::new(None)),
+            session_authorization: pay_core::session_manager::SessionSlot::default(),
             session_opener: build_session_authorization,
             client,
             store,
@@ -356,14 +356,14 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
     // process. Keep the guard until the gateway has accepted and metered this
     // response so two concurrent calls cannot reserve the same channel cap.
     let mut session_authorization = if state.payment_protocol == PaymentProtocol::MppSession {
-        Some(state.session_authorization.clone().lock_owned().await)
+        Some(state.session_authorization.acquire().await)
     } else {
         None
     };
     let cached_payment = session_authorization
-        .as_deref()
-        .and_then(Option::as_ref)
-        .cloned()
+        .as_ref()
+        .and_then(pay_core::session_manager::SessionLease::authorization)
+        .map(str::to_string)
         .map(PaidHeaders::mpp);
     let used_cached_session = cached_payment.is_some();
 
@@ -499,7 +499,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         && !has_session_challenge
     {
         if let Some(cached) = session_authorization.as_mut() {
-            **cached = None;
+            cached.clear();
         }
         tracing::info!(%url, "payer proxy: cached MPP session ended; requesting a fresh challenge");
         let refreshed = match send_upstream(&state, &method, &url, &headers, body.clone(), None)
@@ -547,7 +547,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         && used_cached_session
         && let Some(cached) = session_authorization.as_mut()
     {
-        **cached = None;
+        cached.clear();
     }
 
     let charge_challenges: Vec<_> = mpp_challenges
@@ -632,13 +632,13 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             // channel") that never clears without a manual restart.
             if retry.status() == StatusCode::PAYMENT_REQUIRED {
                 if let Some(cache) = session_authorization.as_mut() {
-                    **cache = None;
+                    cache.clear();
                 }
             } else if let (Some(cache), Some(authorization)) = (
                 session_authorization.as_mut(),
                 new_session_authorization.as_ref(),
             ) {
-                **cache = Some(authorization.clone());
+                cache.adopt(authorization.clone());
             }
             deliver(retry, translated, session_authorization.take()).await
         }
@@ -843,7 +843,7 @@ fn translate_request(
 /// Hand an upstream response back to Claude Code: translated (SSE or
 /// buffered JSON) when the request was translated and succeeded,
 /// streamed passthrough otherwise.
-type SessionAuthorizationGuard = tokio::sync::OwnedMutexGuard<Option<String>>;
+type SessionAuthorizationGuard = pay_core::session_manager::SessionLease;
 
 async fn deliver(
     resp: reqwest::Response,
@@ -994,73 +994,20 @@ fn build_session_authorization(
     state: &PayerState,
     challenge: &pay_core::mpp::Challenge,
 ) -> pay_core::Result<(PaidHeaders, String)> {
-    use pay_kit::mpp::{SessionRequest, SessionVoucherSigner};
-
-    let request: SessionRequest = challenge
-        .request
-        .decode()
-        .map_err(|error| pay_core::Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
-    if request.method_details.voucher_signer != Some(SessionVoucherSigner::Operator) {
-        return Err(pay_core::Error::Mpp(
-            "agent payer requires an operator-signed MPP session".to_string(),
-        ));
-    }
-    if let Some(forced) = state.network_override.as_deref()
-        && forced != request.method_details.network
-    {
-        return Err(pay_core::Error::Mpp(format!(
-            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{}`",
-            request.method_details.network
-        )));
-    }
-
-    let minimum = request
-        .minimum_deposit
-        .as_deref()
-        .map(|value| {
-            value.parse::<u64>().map_err(|_| {
-                pay_core::Error::Mpp(format!(
-                    "MPP session challenge advertised a non-numeric minimumDeposit: {value}"
-                ))
-            })
-        })
-        .transpose()?
-        .unwrap_or(0);
-    let deposit = request
-        .suggested_deposit
-        .as_deref()
-        .map(|value| {
-            value.parse::<u64>().map_err(|_| {
-                pay_core::Error::Mpp(format!(
-                    "MPP session challenge advertised a non-numeric suggestedDeposit: {value}"
-                ))
-            })
-        })
-        .transpose()?
-        .unwrap_or(1_000_000)
-        .max(minimum)
-        .max(1);
     let sandbox = state.network_override.as_deref() == Some("localnet");
-    let (handle, open_authorization) = pay_core::session::open_payment_channel_session_header(
+    let prepared = pay_core::session_manager::prepare_operator_session_with_override(
         challenge,
-        &request,
         state.store.as_ref(),
         state.network_override.as_deref(),
         state.account_override.as_deref(),
-        deposit,
         &state.authorization_url,
         sandbox,
+        None,
     )?;
-
-    // Subsequent requests authenticate with the reusable payer proof bound at
-    // open; the operator meters delivered service and signs the vouchers.
-    let use_authorization = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| pay_core::Error::Mpp(format!("Failed to build runtime: {error}")))?
-        .block_on(handle.use_header())?;
-
-    Ok((PaidHeaders::mpp(open_authorization), use_authorization))
+    Ok((
+        PaidHeaders::mpp(prepared.open_authorization),
+        prepared.use_authorization,
+    ))
 }
 
 /// Select a payable MPP challenge and build the `Authorization: Payment …`
@@ -2211,7 +2158,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
         assert_eq!(
-            state.session_authorization.lock().await.as_deref(),
+            state.session_authorization.acquire().await.authorization(),
             None,
             "an unconfirmed open credential must not be cached — adopting it before \
              a paid retry proves it landed risks stranding a credential for a \
@@ -2502,7 +2449,7 @@ mod tests {
             "a retryable store conflict must retry the same channel without rediscovery",
         );
         assert_eq!(
-            state.session_authorization.lock().await.as_deref(),
+            state.session_authorization.acquire().await.authorization(),
             Some("Payment retryable-session"),
             "a transient 402 must preserve the cached session"
         );

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -32,7 +32,7 @@ async-stream = "0.3"
 futures-util = "0.3"
 openssl-sys = { version = "0.9", optional = true }
 pay-types = { workspace = true }
-schemars = { workspace = true }
+schemars = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }

--- a/rust/crates/core/src/client/mod.rs
+++ b/rust/crates/core/src/client/mod.rs
@@ -8,5 +8,6 @@ pub mod runner;
 pub mod sandbox;
 pub mod send;
 pub mod session;
+pub mod session_manager;
 pub mod subscription;
 pub mod x402;

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -47,9 +47,14 @@ pub enum RunOutcome {
         resource_url: String,
     },
     /// The server returned 402 with an MPP session challenge (intent="session").
-    /// Session payments require a stateful client with a Fiber channel.
+    /// Reusable session clients open a Solana payment channel, then cache its
+    /// authorization for later requests.
     SessionChallenge {
         challenge: Box<mpp::Challenge>,
+        /// x402 alternatives advertised beside the session, retained so a
+        /// client can fall back when it cannot reuse this session shape.
+        x402_alternative: Option<Box<x402::Challenge>>,
+        x402_upto_accepts: Vec<pay_kit::x402::upto::UptoRequirements>,
         advertised_challenges: DecodedPaymentChallenges,
         resource_url: String,
     },
@@ -678,6 +683,12 @@ pub(crate) fn classify_402_with_preference(
     });
     let mpp_challenges = mpp::parse_headers(headers);
     let x402_siwx_challenge = x402::parse_siwx_auth(headers, body);
+    let x402_upto_accepts = x402::parse_upto_accepts(headers, body);
+    let x402_alternative = if x402_upto_accepts.is_empty() {
+        x402_challenge.clone().map(Box::new)
+    } else {
+        None
+    };
 
     // x402::parse (from pay_kit::x402) only returns Some when a Solana-
     // compatible `accepts` entry exists — it's already a Solana filter.
@@ -698,6 +709,8 @@ pub(crate) fn classify_402_with_preference(
             );
             return RunOutcome::SessionChallenge {
                 challenge: Box::new(challenge.clone()),
+                x402_alternative,
+                x402_upto_accepts,
                 advertised_challenges,
                 resource_url: resource_url.to_string(),
             };
@@ -746,12 +759,6 @@ pub(crate) fn classify_402_with_preference(
         // real `upto` is present prefer that reading and drop the (bogus) exact
         // alternative — otherwise the selector could pick an `exact` the server
         // never advertised and the payment would be rejected.
-        let x402_upto_accepts = x402::parse_upto_accepts(headers, body);
-        let x402_alternative = if x402_upto_accepts.is_empty() {
-            x402_challenge.clone().map(Box::new)
-        } else {
-            None
-        };
         return RunOutcome::MppChallenge {
             challenge: Box::new(challenge),
             alternatives: charge_challenges,
@@ -1940,7 +1947,12 @@ HTTP request sent, awaiting response...
             "https://example.com/resource",
             ProtocolPreference::Auto,
         );
-        assert!(matches!(outcome, RunOutcome::SessionChallenge { .. }));
+        match outcome {
+            RunOutcome::SessionChallenge {
+                x402_alternative, ..
+            } => assert!(x402_alternative.is_some()),
+            other => panic!("expected session challenge, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -271,6 +271,33 @@ pub fn open_payment_channel_session_header(
     resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
+    open_payment_channel_session_header_with_override(
+        challenge,
+        request,
+        store,
+        network_override,
+        account_override,
+        deposit,
+        resource_url,
+        sandbox,
+        None,
+    )
+}
+
+/// Variant of [`open_payment_channel_session_header`] that accepts an
+/// optional auth-gate override for MCP elicitation-backed approval.
+#[allow(clippy::too_many_arguments)]
+pub fn open_payment_channel_session_header_with_override(
+    challenge: &PaymentChallenge,
+    request: &SessionRequest,
+    store: &dyn crate::accounts::AccountsStore,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    deposit: u64,
+    resource_url: &str,
+    sandbox: bool,
+    auth_override: crate::signer::AuthOverride,
+) -> Result<(SessionHandle, String)> {
     use pay_kit::mpp::client::{
         DerivePaymentChannelOpenParams, PaymentChannelOpenOptions,
         PaymentChannelSessionOpenOptions, create_payment_channel_session_opener,
@@ -291,12 +318,14 @@ pub fn open_payment_channel_session_header(
         &limit.display,
         &prompt_context.operator,
     );
-    let (signer, ephemeral_notice) = crate::signer::load_signer_for_network_with_intent(
-        &network,
-        store,
-        account_override,
-        &intent,
-    )?;
+    let (signer, ephemeral_notice) =
+        crate::signer::load_signer_for_network_with_intent_and_override(
+            &network,
+            store,
+            account_override,
+            &intent,
+            auth_override,
+        )?;
     let payer = signer.pubkey();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -425,9 +454,19 @@ pub fn voucher_header_sync(handle: &SessionHandle, amount: u64) -> Result<String
     rt.block_on(handle.voucher_header(amount))
 }
 
+/// Build the reusable operator-signed `use` credential from synchronous
+/// client frontends such as the payer proxy and MCP curl worker.
+pub fn use_header_sync(handle: &SessionHandle) -> Result<String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| Error::Mpp(format!("Failed to build runtime: {e}")))?;
+    rt.block_on(handle.use_header())
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-pub(crate) fn canonical_session_origin(resource_url: &str) -> Result<String> {
+pub fn canonical_session_origin(resource_url: &str) -> Result<String> {
     let url = reqwest::Url::parse(resource_url)
         .map_err(|e| Error::Mpp(format!("invalid session authorization URL: {e}")))?;
     if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {

--- a/rust/crates/core/src/client/session_manager.rs
+++ b/rust/crates/core/src/client/session_manager.rs
@@ -1,0 +1,264 @@
+//! Reusable client-side MPP session state.
+//!
+//! Frontends keep transport concerns, while this module owns session scoping,
+//! serialization, credential adoption, and operator-session preparation.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use pay_kit::mpp::{PaymentChallenge, SessionRequest, SessionVoucherSigner};
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use crate::accounts::AccountsStore;
+use crate::client::session;
+use crate::{Error, Result};
+
+/// Identity of one reusable client session.
+///
+/// Provider gateways are isolated by origin. Network and account overrides
+/// are part of the key so changing either cannot reuse another payer's proof.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SessionKey {
+    origin: String,
+    network: Option<String>,
+    account: Option<String>,
+}
+
+impl SessionKey {
+    pub fn for_resource(
+        resource_url: &str,
+        network: Option<&str>,
+        account: Option<&str>,
+    ) -> Result<Self> {
+        Ok(Self {
+            origin: session::canonical_session_origin(resource_url)?,
+            network: network.map(str::to_string),
+            account: account.map(str::to_string),
+        })
+    }
+}
+
+/// One serialized session credential slot.
+#[derive(Clone, Default)]
+pub struct SessionSlot {
+    credential: Arc<Mutex<Option<String>>>,
+}
+
+impl SessionSlot {
+    pub async fn acquire(&self) -> SessionLease {
+        SessionLease {
+            credential: self.credential.clone().lock_owned().await,
+        }
+    }
+
+    /// Acquire from a blocking worker thread.
+    ///
+    /// This must not run on a Tokio async worker. MCP curl calls it inside its
+    /// existing `spawn_blocking` payment worker.
+    pub fn blocking_acquire(&self) -> SessionLease {
+        SessionLease {
+            credential: self.credential.clone().blocking_lock_owned(),
+        }
+    }
+}
+
+/// Exclusive access to one provider session for the duration of a request.
+///
+/// Holding the lease until the response body is received prevents concurrent
+/// requests from reserving the same remaining channel capacity.
+pub struct SessionLease {
+    credential: OwnedMutexGuard<Option<String>>,
+}
+
+impl SessionLease {
+    pub fn authorization(&self) -> Option<&str> {
+        self.credential.as_deref()
+    }
+
+    /// Adopt a new reusable credential after its open request succeeds.
+    pub fn adopt(&mut self, authorization: String) {
+        *self.credential = Some(authorization);
+    }
+
+    /// Forget a credential that the gateway has definitively rejected.
+    pub fn clear(&mut self) {
+        *self.credential = None;
+    }
+}
+
+/// Process-lifetime registry of sessions used by multi-provider clients.
+#[derive(Clone, Default)]
+pub struct SessionManager {
+    slots: Arc<StdMutex<HashMap<SessionKey, SessionSlot>>>,
+}
+
+impl SessionManager {
+    pub fn slot(
+        &self,
+        resource_url: &str,
+        network: Option<&str>,
+        account: Option<&str>,
+    ) -> Result<SessionSlot> {
+        let key = SessionKey::for_resource(resource_url, network, account)?;
+        let mut slots = self
+            .slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Ok(slots.entry(key).or_default().clone())
+    }
+}
+
+/// Authorization pair prepared for the first request and later reuse.
+pub struct PreparedOperatorSession {
+    pub open_authorization: String,
+    pub use_authorization: String,
+}
+
+/// Whether this challenge can produce a reusable agent session credential.
+pub fn is_operator_session(challenge: &PaymentChallenge) -> bool {
+    challenge
+        .request
+        .decode::<SessionRequest>()
+        .ok()
+        .is_some_and(|request| {
+            request.method_details.voucher_signer == Some(SessionVoucherSigner::Operator)
+        })
+}
+
+/// Open an operator-signed MPP session and prepare its reusable `use` proof.
+///
+/// The caller must cache `use_authorization` only after the request carrying
+/// `open_authorization` receives a non-402 response.
+#[allow(clippy::too_many_arguments)]
+pub fn prepare_operator_session_with_override(
+    challenge: &PaymentChallenge,
+    store: &dyn AccountsStore,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    resource_url: &str,
+    sandbox: bool,
+    auth_override: crate::signer::AuthOverride,
+) -> Result<PreparedOperatorSession> {
+    let request: SessionRequest = challenge
+        .request
+        .decode()
+        .map_err(|error| Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
+    if request.method_details.voucher_signer != Some(SessionVoucherSigner::Operator) {
+        return Err(Error::Mpp(
+            "reusable agent sessions require voucherSigner `operator`".to_string(),
+        ));
+    }
+    if let Some(forced) = network_override
+        && forced != request.method_details.network
+    {
+        return Err(Error::Mpp(format!(
+            "MPP session network mismatch: client requires `{forced}`, gateway offered `{}`",
+            request.method_details.network
+        )));
+    }
+
+    let deposit = session_deposit(&request)?;
+    let (handle, open_authorization) = session::open_payment_channel_session_header_with_override(
+        challenge,
+        &request,
+        store,
+        network_override,
+        account_override,
+        deposit,
+        resource_url,
+        sandbox,
+        auth_override,
+    )?;
+    let use_authorization = session::use_header_sync(&handle)?;
+
+    Ok(PreparedOperatorSession {
+        open_authorization,
+        use_authorization,
+    })
+}
+
+fn session_deposit(request: &SessionRequest) -> Result<u64> {
+    let minimum =
+        parse_optional_amount("minimumDeposit", request.minimum_deposit.as_deref())?.unwrap_or(0);
+    let suggested =
+        parse_optional_amount("suggestedDeposit", request.suggested_deposit.as_deref())?
+            .unwrap_or(1_000_000);
+    Ok(suggested.max(minimum).max(1))
+}
+
+fn parse_optional_amount(field: &str, value: Option<&str>) -> Result<Option<u64>> {
+    value
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                Error::Mpp(format!(
+                    "MPP session challenge advertised a non-numeric {field}: `{value}`"
+                ))
+            })
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_key_is_scoped_to_origin_and_payer_context() {
+        let first = SessionKey::for_resource(
+            "https://api.example.com/v1/chat?model=x",
+            Some("mainnet"),
+            Some("payer-a"),
+        )
+        .unwrap();
+        let same_origin = SessionKey::for_resource(
+            "https://api.example.com/v1/models",
+            Some("mainnet"),
+            Some("payer-a"),
+        )
+        .unwrap();
+        let other_payer = SessionKey::for_resource(
+            "https://api.example.com/v1/chat",
+            Some("mainnet"),
+            Some("payer-b"),
+        )
+        .unwrap();
+
+        assert_eq!(first, same_origin);
+        assert_ne!(first, other_payer);
+    }
+
+    #[test]
+    fn manager_reuses_a_slot_for_the_same_scope() {
+        let manager = SessionManager::default();
+        let first = manager
+            .slot("https://api.example.com/a", None, None)
+            .unwrap();
+        let second = manager
+            .slot("https://api.example.com/b", None, None)
+            .unwrap();
+
+        first
+            .blocking_acquire()
+            .adopt("Payment use-proof".to_string());
+        assert_eq!(
+            second.blocking_acquire().authorization(),
+            Some("Payment use-proof")
+        );
+    }
+
+    #[test]
+    fn manager_isolates_different_origins() {
+        let manager = SessionManager::default();
+        let first = manager
+            .slot("https://one.example.com/a", None, None)
+            .unwrap();
+        let second = manager
+            .slot("https://two.example.com/a", None, None)
+            .unwrap();
+
+        first
+            .blocking_acquire()
+            .adopt("Payment use-proof".to_string());
+        assert!(second.blocking_acquire().authorization().is_none());
+    }
+}

--- a/rust/crates/core/src/instructions.md
+++ b/rust/crates/core/src/instructions.md
@@ -7,6 +7,9 @@ Never answer "Can pay do X" from memory; check `list_catalog`.
 
 - Capability or feasibility question: call `list_catalog()` before answering.
   Examples: "can I use pay to ...", "does pay support ...", "what can pay do".
+  If the catalog does not cover the need, call `search_catalog` with the user's
+  real task before answering "no" — on a miss it offers to submit a capability
+  request to the studio registry.
 - Task needs a provider: call `search_catalog({query})` with the user's real
   task, not just a category or provider name.
 - Known provider FQN: call `get_catalog_entry({fqn})`.

--- a/rust/crates/core/src/instructions.md
+++ b/rust/crates/core/src/instructions.md
@@ -8,11 +8,12 @@ Never answer "Can pay do X" from memory; check `list_catalog`.
 - Capability or feasibility question: call `list_catalog()` before answering.
   Examples: "can I use pay to ...", "does pay support ...", "what can pay do".
   If the catalog does not cover the need, call `search_catalog` with the user's
-  real task before answering "no" — on a real miss it prompts the user itself
-  with an offer to have the capability built (never pre-ask in chat; the
-  tool's prompt is the consent step). A catalog gap is an agentic business
-  opportunity — the user can get the API built, published, and monetized
-  under them — so present it that way, never as paperwork.
+  real task before answering "no" — on a real miss the same resumable tool call
+  prompts for consent, refines a quote-ready brief locally, and submits it to
+  studios (never pre-ask in chat; the tool's prompt is the consent step). A
+  catalog gap is an agentic business opportunity — the user can get the API
+  built, published, and monetized under them — so present it that way, never as
+  paperwork.
 - Task needs a provider: call `search_catalog({query})` with the user's real
   task, not just a category or provider name.
 - Known provider FQN: call `get_catalog_entry({fqn})`.
@@ -61,10 +62,10 @@ ad-hoc page scraping.
 - Wrong network/currency, unsupported payment protocol, or price above the
   user's limit: stop and explain.
 - Empty or stale provider results: retry once with `search_catalog({refresh:
-  true})`; if still empty, `search_catalog` itself elicits consent to submit a
-  capability request to the studio registry — do not call `request_capability`
-  again afterward for the same query. If elicitation isn't supported, ask
-  before using a non-Pay fallback.
+  true})`; if still empty, `search_catalog` itself enters MRTR to collect
+  consent, refine the brief locally, and submit it — do not call
+  `request_capability` again afterward for the same query. If MRTR isn't
+  supported, nothing is submitted; ask before using a non-Pay fallback.
 - Missing stablecoin balance: call `get_balance()` and explain the shortfall.
 - 404 or unusable endpoint shape: try at most one documented fallback endpoint,
   then ask.

--- a/rust/crates/core/src/instructions.md
+++ b/rust/crates/core/src/instructions.md
@@ -8,8 +8,11 @@ Never answer "Can pay do X" from memory; check `list_catalog`.
 - Capability or feasibility question: call `list_catalog()` before answering.
   Examples: "can I use pay to ...", "does pay support ...", "what can pay do".
   If the catalog does not cover the need, call `search_catalog` with the user's
-  real task before answering "no" — on a miss it offers to submit a capability
-  request to the studio registry.
+  real task before answering "no" — on a real miss it prompts the user itself
+  with an offer to have the capability built (never pre-ask in chat; the
+  tool's prompt is the consent step). A catalog gap is an agentic business
+  opportunity — the user can get the API built, published, and monetized
+  under them — so present it that way, never as paperwork.
 - Task needs a provider: call `search_catalog({query})` with the user's real
   task, not just a category or provider name.
 - Known provider FQN: call `get_catalog_entry({fqn})`.

--- a/rust/crates/core/src/instructions.md
+++ b/rust/crates/core/src/instructions.md
@@ -55,7 +55,10 @@ ad-hoc page scraping.
 - Wrong network/currency, unsupported payment protocol, or price above the
   user's limit: stop and explain.
 - Empty or stale provider results: retry once with `search_catalog({refresh:
-  true})`; if still empty, ask before using a non-Pay fallback.
+  true})`; if still empty, `search_catalog` itself elicits consent to submit a
+  capability request to the studio registry — do not call `request_capability`
+  again afterward for the same query. If elicitation isn't supported, ask
+  before using a non-Pay fallback.
 - Missing stablecoin balance: call `get_balance()` and explain the shortfall.
 - 404 or unusable endpoint shape: try at most one documented fallback endpoint,
   then ask.

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod instructions;
 pub mod keystore;
 pub mod signer;
 pub mod skills;
+pub mod studios;
 pub mod user_agent;
 
 // Client modules (CLI)

--- a/rust/crates/core/src/lib.rs
+++ b/rust/crates/core/src/lib.rs
@@ -25,6 +25,7 @@ pub use client::runner::{
 pub use client::sandbox;
 pub use client::send;
 pub use client::session;
+pub use client::session_manager;
 pub use client::x402;
 
 // Server modules (gateway proxy)

--- a/rust/crates/core/src/skills/mod.rs
+++ b/rust/crates/core/src/skills/mod.rs
@@ -200,6 +200,13 @@ pub struct RankedServiceSummary {
     pub service: ServiceSummary,
     pub score: u32,
     pub reasons: Vec<String>,
+    /// Whether this candidate clearly fits the query (whole-query hit on
+    /// name/title/use-case/description/endpoint, ≥75% of query terms
+    /// matched, or a name/title term hit with ≥50% coverage). Term-overlap
+    /// noise — shared catalog namespaces, substring coincidences — never
+    /// sets this, so "no strong candidate" is the catalog-miss signal for
+    /// the capability-request path.
+    pub strong: bool,
 }
 
 /// Level 2 result: a resource group returned by [`service_detail`].
@@ -397,6 +404,7 @@ pub fn search_services_ranked(
     let terms = tokenize_query(query);
     let query_lower = query.trim().to_lowercase();
     let limit = limit.clamp(1, 20);
+    let namespace_orgs = namespace_orgs(catalog);
 
     let mut ranked: Vec<RankedServiceSummary> = catalog
         .providers
@@ -407,7 +415,8 @@ pub fn search_services_ranked(
                 .unwrap_or(true)
         })
         .filter_map(|svc| {
-            let (score, reasons) = score_service_for_query(svc, &query_lower, &terms);
+            let (score, reasons, strong) =
+                score_service_for_query(svc, &query_lower, &terms, &namespace_orgs);
             if score == 0 {
                 return None;
             }
@@ -415,6 +424,7 @@ pub fn search_services_ranked(
                 service: summarize_service(svc),
                 score,
                 reasons,
+                strong,
             })
         })
         .collect();
@@ -427,6 +437,28 @@ pub fn search_services_ranked(
     });
     ranked.truncate(limit);
     ranked
+}
+
+/// Query-specificity floor for the weak-results half of
+/// [`is_catalog_miss`]: with fewer meaningful terms the query is too vague
+/// to distinguish "the catalog lacks this" from "the phrasing matched
+/// poorly", and the capability-request prompt would fire on ordinary fuzzy
+/// searches.
+const SPECIFIC_QUERY_TERMS: usize = 4;
+
+/// Whether a ranked search outcome counts as a catalog miss for the
+/// capability-request flow: a hard miss (nothing matched at all), or a
+/// specific query (>= [`SPECIFIC_QUERY_TERMS`] meaningful terms) that
+/// produced only weak keyword noise. Measured on the 900-case routing
+/// fixture (`pay-mcp` bench): never fires when a strong candidate exists,
+/// ~6% of vague covered prompts hard-miss and ~4% of specific covered
+/// prompts are weak-only — each false fire costs one declined elicitation,
+/// not a submission.
+pub fn is_catalog_miss(query: &str, ranked: &[RankedServiceSummary]) -> bool {
+    if ranked.is_empty() {
+        return true;
+    }
+    !ranked.iter().any(|r| r.strong) && tokenize_query(query).len() >= SPECIFIC_QUERY_TERMS
 }
 
 fn tokenize_query(query: &str) -> Vec<String> {
@@ -498,11 +530,32 @@ fn tokenize_query(query: &str) -> Vec<String> {
         .collect()
 }
 
+/// Catalog org prefixes shared by 3+ providers. A curation namespace like
+/// `solana-foundation/` appears on dozens of unrelated providers, so a query
+/// term matching only that prefix carries no information about the provider
+/// (the classic failure: "solana …" matched every curated entry, surfacing
+/// an air-quality API for a priority-fee query). A brand org that fronts one
+/// or two providers (`quicknode/`, `vybenetwork/`) stays matchable.
+fn namespace_orgs(catalog: &Catalog) -> std::collections::HashSet<String> {
+    let mut counts: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
+    for svc in &catalog.providers {
+        if let Some((org, _)) = svc.fqn.split_once('/') {
+            *counts.entry(org).or_default() += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter(|(_, n)| *n >= 3)
+        .map(|(org, _)| org.to_lowercase())
+        .collect()
+}
+
 fn score_service_for_query(
     svc: &Service,
     query_lower: &str,
     terms: &[String],
-) -> (u32, Vec<String>) {
+    namespace_orgs: &std::collections::HashSet<String>,
+) -> (u32, Vec<String>, bool) {
     let mut score = 0u32;
     let mut reasons = Vec::new();
 
@@ -513,35 +566,51 @@ fn score_service_for_query(
     let use_case = svc.meta.use_case.clone().unwrap_or_default().to_lowercase();
     let category = svc.meta.category.to_lowercase();
 
+    // Term matching sees the fqn without a shared curation namespace; the
+    // whole-query checks below keep the full fqn (an exact ask for a
+    // namespaced provider should still hit).
+    let fqn_for_terms = match fqn.split_once('/') {
+        Some((org, rest)) if namespace_orgs.contains(org) => rest,
+        _ => fqn.as_str(),
+    };
+
+    let mut whole_query_hit = false;
     if !query_lower.is_empty() {
         if fqn.contains(query_lower) || short_name.contains(query_lower) {
             score += 90;
+            whole_query_hit = true;
             reasons.push("provider name matches the task".to_string());
         }
         if title.contains(query_lower) {
             score += 80;
+            whole_query_hit = true;
             reasons.push("provider title matches the task".to_string());
         }
         if use_case.contains(query_lower) {
             score += 70;
+            whole_query_hit = true;
             reasons.push("provider use case directly matches the task".to_string());
         }
         if description.contains(query_lower) {
             score += 55;
+            whole_query_hit = true;
             reasons.push("provider description matches the task".to_string());
         }
     }
 
     let mut matched_terms = 0u32;
+    let mut name_term_hit = false;
     for term in terms {
         let mut term_matched = false;
-        if contains_query_term(&fqn, term) || contains_query_term(&short_name, term) {
+        if contains_query_term(fqn_for_terms, term) || contains_query_term(&short_name, term) {
             score += 24;
             term_matched = true;
+            name_term_hit = true;
         }
         if contains_query_term(&title, term) {
             score += 18;
             term_matched = true;
+            name_term_hit = true;
         }
         if contains_query_term(&use_case, term) {
             score += 14;
@@ -564,8 +633,9 @@ fn score_service_for_query(
         }
     }
 
+    let mut coverage = 0u32;
     if !terms.is_empty() {
-        let coverage = matched_terms * 100 / terms.len() as u32;
+        coverage = matched_terms * 100 / terms.len() as u32;
         score += coverage;
         if coverage == 100 {
             reasons.push("all important query terms match this provider".to_string());
@@ -588,15 +658,21 @@ fn score_service_for_query(
         })
     {
         score += 45;
+        whole_query_hit = true;
         reasons.push("a specific endpoint matches the task".to_string());
     }
 
-    if svc.endpoint_count <= 5 {
-        score += 12;
-    } else if svc.endpoint_count <= 20 {
-        score += 6;
-    } else if svc.endpoint_count >= 100 {
-        score = score.saturating_sub(8);
+    // Size adjustment is a tiebreaker between real matches, not evidence:
+    // without the score-gate a zero-match 2-endpoint provider still scored
+    // 12 and showed up as a "candidate" for any query.
+    if score > 0 {
+        if svc.endpoint_count <= 5 {
+            score += 12;
+        } else if svc.endpoint_count <= 20 {
+            score += 6;
+        } else if svc.endpoint_count >= 100 {
+            score = score.saturating_sub(8);
+        }
     }
 
     if is_demo_provider(&fqn, &description) && !query_mentions_demo(query_lower, terms) {
@@ -607,7 +683,19 @@ fn score_service_for_query(
         reasons.push("provider metadata partially matches the task".to_string());
     }
 
-    (score, reasons)
+    // "Clearly fits": the full query appeared somewhere meaningful, most
+    // query terms matched, or a term hit the provider's own name/title
+    // (high signal — the provider is named after the thing) alongside at
+    // least half the terms. Queries carry words a fitting provider
+    // legitimately lacks ("find … in paris"), so 100% coverage is not
+    // required; prose-only matches on a minority of terms ("solana" in a
+    // description) stay weak. Weak candidates are still returned for the
+    // caller to weigh, but they are not evidence the capability exists.
+    let strong = whole_query_hit
+        || (!terms.is_empty() && coverage >= 75)
+        || (name_term_hit && coverage >= 50);
+
+    (score, reasons, strong)
 }
 
 fn endpoint_term_matches(svc: &Service, term: &str) -> bool {
@@ -2504,7 +2592,10 @@ mod tests {
         let cat = catalog_for_provider_routing();
         let results = search_services_ranked(&cat, "find instagram influencers in paris", None, 5);
         assert_eq!(results[0].service.name, "socialintel/influencer-search");
-        assert!(results[0].score > results[1].score);
+        // The broad providers match no query term; the size bonus alone used
+        // to keep them in the list (score 6-12), which is exactly the noise
+        // the score-gate removes.
+        assert_eq!(results.len(), 1);
     }
 
     #[test]
@@ -2540,6 +2631,167 @@ mod tests {
             results[0].service.name,
             "solana-foundation/payment-debugger"
         );
+    }
+
+    /// Reproduces the "solana priority fee forecasts" failure: a curation
+    /// namespace shared by most of the catalog, plus a provider whose name
+    /// only coincidentally overlaps the query ("fee" in "pricefeeds").
+    fn catalog_with_shared_namespace() -> Catalog {
+        let json = r#"{
+            "version": "1",
+            "generated_at": "2026-04-21T00:00:00Z",
+            "base_url": "https://cdn.example.com/v1",
+            "providers": [
+                {
+                    "fqn": "solana-foundation/air-quality",
+                    "title": "Air Quality API",
+                    "description": "Real-time air quality index by location.",
+                    "use_case": "Use for pollution monitoring and AQI lookups.",
+                    "category": "data",
+                    "service_url": "https://air.example.com",
+                    "endpoint_count": 2,
+                    "has_metering": true,
+                    "min_price_usd": 0.01,
+                    "max_price_usd": 0.01,
+                    "sha": "air"
+                },
+                {
+                    "fqn": "solana-foundation/text-to-speech",
+                    "title": "Text to Speech",
+                    "description": "Neural TTS voices.",
+                    "use_case": "Use for speech synthesis and narration.",
+                    "category": "media",
+                    "service_url": "https://tts.example.com",
+                    "endpoint_count": 3,
+                    "has_metering": true,
+                    "min_price_usd": 0.02,
+                    "max_price_usd": 0.2,
+                    "sha": "tts"
+                },
+                {
+                    "fqn": "solana-foundation/fact-check",
+                    "title": "Fact Check",
+                    "description": "Claim verification against fact-check databases.",
+                    "use_case": "Use for verifying claims and misinformation checks.",
+                    "category": "search",
+                    "service_url": "https://facts.example.com",
+                    "endpoint_count": 1,
+                    "has_metering": true,
+                    "min_price_usd": 0.005,
+                    "max_price_usd": 0.005,
+                    "sha": "facts"
+                },
+                {
+                    "fqn": "solana-foundation/pricefeeds",
+                    "title": "Price Feeds",
+                    "description": "Crypto and stock price feeds.",
+                    "use_case": "Use for token prices, stock quotes, and market data.",
+                    "category": "finance",
+                    "service_url": "https://prices.example.com",
+                    "endpoint_count": 4,
+                    "has_metering": true,
+                    "min_price_usd": 0.001,
+                    "max_price_usd": 0.01,
+                    "sha": "prices"
+                },
+                {
+                    "fqn": "quicknode/rpc",
+                    "title": "QuickNode",
+                    "description": "Pay-per-request JSON-RPC access to blockchain networks including Solana.",
+                    "use_case": "Use for raw blockchain RPC methods, Solana getSlot, account reads, transaction submission, and chain data access.",
+                    "category": "compute",
+                    "service_url": "https://quicknode.example.com",
+                    "endpoint_count": 1,
+                    "has_metering": true,
+                    "min_price_usd": 0.01,
+                    "max_price_usd": 0.01,
+                    "sha": "quicknode"
+                }
+            ]
+        }"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn catalog_miss_fires_on_empty_results() {
+        assert!(is_catalog_miss("watercooling a macbook", &[]));
+    }
+
+    #[test]
+    fn catalog_miss_fires_on_specific_query_with_only_weak_matches() {
+        let cat = catalog_with_shared_namespace();
+        let results = search_services_ranked(&cat, "solana priority fee forecasts", None, 5);
+        assert!(!results.is_empty());
+        assert!(is_catalog_miss("solana priority fee forecasts", &results));
+    }
+
+    #[test]
+    fn catalog_miss_holds_back_on_vague_query_with_weak_matches() {
+        let cat = catalog_for_provider_routing();
+        // Covered by quicknode/rpc but phrased fuzzily: only "transaction"
+        // matches, so nothing is strong — with two meaningful terms the
+        // query is too vague to treat as a gap, and the model-mediated
+        // request_capability hint takes over instead of a prompt.
+        let results = search_services_ranked(&cat, "push this transaction", None, 5);
+        assert!(!results.is_empty());
+        assert!(results.iter().all(|r| !r.strong));
+        assert!(!is_catalog_miss("push this transaction", &results));
+    }
+
+    #[test]
+    fn catalog_miss_negative_when_strong_candidate_exists() {
+        let cat = catalog_for_provider_routing();
+        let query = "find instagram influencers in paris";
+        let results = search_services_ranked(&cat, query, None, 5);
+        assert!(results.iter().any(|r| r.strong));
+        assert!(!is_catalog_miss(query, &results));
+    }
+
+    #[test]
+    fn ranked_search_shared_namespace_earns_no_term_credit() {
+        let cat = catalog_with_shared_namespace();
+        let results = search_services_ranked(&cat, "solana priority fee forecasts", None, 5);
+        // Term-overlap noise still returns candidates ("solana" in
+        // quicknode's use case) but none of them clearly fits, so none is
+        // strong — the capability-request offer in search_catalog keys off
+        // exactly this.
+        assert!(!results.is_empty());
+        assert!(results.iter().all(|r| !r.strong));
+        // The air-quality API previously scored on this query purely via the
+        // shared `solana-foundation/` prefix; with namespace credit gone it
+        // matches no term at all.
+        assert!(
+            !results
+                .iter()
+                .any(|r| r.service.name == "solana-foundation/air-quality")
+        );
+    }
+
+    #[test]
+    fn ranked_search_shared_namespace_still_matches_whole_fqn_query() {
+        let cat = catalog_with_shared_namespace();
+        let results = search_services_ranked(&cat, "solana-foundation/air-quality", None, 5);
+        assert_eq!(results[0].service.name, "solana-foundation/air-quality");
+        assert!(results[0].strong);
+    }
+
+    #[test]
+    fn ranked_search_brand_org_keeps_term_credit() {
+        let cat = catalog_with_shared_namespace();
+        // `quicknode/` fronts a single provider, so the org prefix is a brand
+        // name, not a curation namespace — it must stay matchable.
+        let results = search_services_ranked(&cat, "quicknode getslot", None, 5);
+        assert_eq!(results[0].service.name, "quicknode/rpc");
+        assert!(results[0].strong);
+    }
+
+    #[test]
+    fn ranked_search_marks_clear_fit_strong() {
+        let cat = catalog_for_provider_routing();
+        let results = search_services_ranked(&cat, "find instagram influencers in paris", None, 5);
+        let top = &results[0];
+        assert_eq!(top.service.name, "socialintel/influencer-search");
+        assert!(top.strong);
     }
 
     // ── find_service ────────────────────────────────────────────────────────

--- a/rust/crates/core/src/studios/mod.rs
+++ b/rust/crates/core/src/studios/mod.rs
@@ -96,7 +96,15 @@ pub struct NewCapabilityRequest {
     pub competition: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub budget_ceiling: Option<BudgetAmount>,
-    pub buyer_npub: String,
+    /// Buyer identity, Nostr side. The studio requires at least one of
+    /// `buyer_npub` / `buyer_solana_pubkey`; the MCP intake path attributes
+    /// with the Solana key the engagement would be funded with and never
+    /// collects an npub.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub buyer_npub: Option<String>,
+    /// Buyer identity, Solana side — the local Pay wallet's pubkey.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub buyer_solana_pubkey: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -229,8 +237,8 @@ mod tests {
             monetization: None,
             competition: vec![],
             budget_ceiling: None,
-            buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
-                .to_string(),
+            buyer_npub: None,
+            buyer_solana_pubkey: Some("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T".to_string()),
         };
         let json = serde_json::to_value(&request).unwrap();
         let obj = json.as_object().unwrap();
@@ -238,6 +246,14 @@ mod tests {
         assert!(!obj.contains_key("monetization"));
         assert!(!obj.contains_key("competition"));
         assert!(!obj.contains_key("budget_ceiling"));
+        // Absent identity halves must be omitted, not serialized as null —
+        // the studio's `NewRfq` treats explicit null as a present-but-invalid
+        // value for the schema regex.
+        assert!(!obj.contains_key("buyer_npub"));
+        assert_eq!(
+            obj["buyer_solana_pubkey"],
+            "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+        );
         assert_eq!(obj["query"], "solana priority fee forecast api");
     }
 
@@ -252,10 +268,16 @@ mod tests {
                 amount: 10_000_000,
                 mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
             }),
-            buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
-                .to_string(),
+            buyer_npub: Some(
+                "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy".to_string(),
+            ),
+            buyer_solana_pubkey: None,
         };
         let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            json["buyer_npub"],
+            "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
+        );
         assert_eq!(json["product"], "a live forecast endpoint");
         assert_eq!(json["competition"][0], "incumbent/api");
         assert_eq!(json["budget_ceiling"]["amount"], 10_000_000);

--- a/rust/crates/core/src/studios/mod.rs
+++ b/rust/crates/core/src/studios/mod.rs
@@ -1,0 +1,267 @@
+//! Studio registry — v0 static config naming which studios receive RFQ
+//! fan-out from the MCP `commission_capability` tool (commission-flow
+//! draft-00, concrete delta 3). One entry per studio; `~/.config/pay/studios.yaml`
+//! overrides the shipped default so a local `scarced` dev instance can stand
+//! in for the production endpoint during development.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ClientApp, Error, Result};
+
+const STUDIOS_CONFIG_FILE: &str = "~/.config/pay/studios.yaml";
+
+const DEFAULT_STUDIO_NAME: &str = "scarce";
+const DEFAULT_RFQ_URL: &str = "https://scarce.sh/api/v1/rfqs";
+
+const SUBMIT_TIMEOUT: Duration = Duration::from_secs(15);
+const POLL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One studio the registry will fan an RFQ out to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Studio {
+    /// Display name (e.g. "scarce").
+    pub name: String,
+    /// `POST` target that accepts the `NewCommission` wire body (mirrors
+    /// `scarce-studio`'s `studio-types::NewRfq` / `schemas/rfq.json`) and
+    /// returns the captured RFQ record.
+    pub rfq_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StudioRegistry {
+    #[serde(default)]
+    pub studios: Vec<Studio>,
+}
+
+impl Default for StudioRegistry {
+    fn default() -> Self {
+        Self {
+            studios: vec![Studio {
+                name: DEFAULT_STUDIO_NAME.to_string(),
+                rfq_url: DEFAULT_RFQ_URL.to_string(),
+            }],
+        }
+    }
+}
+
+impl StudioRegistry {
+    pub fn load() -> Result<Self> {
+        let path = config_path();
+        if !path.exists()
+            || std::fs::read_to_string(&path)
+                .map(|raw| raw.trim().is_empty())
+                .unwrap_or(true)
+        {
+            let cfg = Self::default();
+            let _ = cfg.save(); // persist so the user can see/edit it
+            return Ok(cfg);
+        }
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| Error::Config(format!("read {}: {e}", path.display())))?;
+        serde_yml::from_str(&raw)
+            .map_err(|e| Error::Config(format!("parse {}: {e}", path.display())))
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = config_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| Error::Config(format!("mkdir: {e}")))?;
+        }
+        let yaml =
+            serde_yml::to_string(self).map_err(|e| Error::Config(format!("serialize: {e}")))?;
+        std::fs::write(&path, yaml)
+            .map_err(|e| Error::Config(format!("write {}: {e}", path.display())))
+    }
+}
+
+fn config_path() -> PathBuf {
+    PathBuf::from(shellexpand::tilde(STUDIOS_CONFIG_FILE).into_owned())
+}
+
+/// Wire shape POSTed to a studio's `rfq_url`. Kept as a plain DTO here
+/// rather than a cross-repo dependency on `scarce-studio`'s `studio-types`
+/// crate; a field mismatch surfaces as a 422 from the studio, which
+/// [`submit_to_registry`] reports verbatim rather than papering over.
+#[derive(Debug, Clone, Serialize)]
+pub struct NewCommission {
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monetization: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub competition: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget_ceiling: Option<CommissionAmount>,
+    pub buyer_npub: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommissionAmount {
+    pub amount: u64,
+    pub mint: String,
+}
+
+/// Outcome of POSTing a commission RFQ to one studio.
+#[derive(Debug, Clone, Serialize)]
+pub struct StudioSubmission {
+    pub studio: String,
+    pub rfq_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rfq: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// POST `commission` to every registered studio. Independent per studio —
+/// one being unreachable or rejecting the submission never fails the
+/// others (commission-flow draft-00 step 3: "quotes return by deadline or
+/// silently decline").
+pub async fn submit_to_registry(
+    registry: &StudioRegistry,
+    commission: &NewCommission,
+    client_app: ClientApp,
+) -> Result<Vec<StudioSubmission>> {
+    let client = reqwest::Client::builder()
+        .timeout(SUBMIT_TIMEOUT)
+        .user_agent(client_app.user_agent())
+        .build()
+        .map_err(|e| Error::Config(format!("http client: {e}")))?;
+
+    let mut submissions = Vec::with_capacity(registry.studios.len());
+    for studio in &registry.studios {
+        submissions.push(submit_one(&client, studio, commission).await);
+    }
+    Ok(submissions)
+}
+
+async fn submit_one(
+    client: &reqwest::Client,
+    studio: &Studio,
+    commission: &NewCommission,
+) -> StudioSubmission {
+    let base = StudioSubmission {
+        studio: studio.name.clone(),
+        rfq_url: studio.rfq_url.clone(),
+        rfq: None,
+        error: None,
+    };
+    match client.post(&studio.rfq_url).json(commission).send().await {
+        Ok(resp) if resp.status().is_success() => match resp.json::<serde_json::Value>().await {
+            Ok(rfq) => StudioSubmission {
+                rfq: Some(rfq),
+                ..base
+            },
+            Err(e) => StudioSubmission {
+                error: Some(format!("invalid response body: {e}")),
+                ..base
+            },
+        },
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            StudioSubmission {
+                error: Some(format!("{status}: {body}")),
+                ..base
+            }
+        }
+        Err(e) => StudioSubmission {
+            error: Some(e.to_string()),
+            ..base
+        },
+    }
+}
+
+/// Poll one studio's free quote-status read for `rfq_id`, derived from
+/// `rfq_url`'s base (`.../api/v1/rfqs` → `.../api/v1/rfqs/{id}/quote`).
+/// Returns `Ok(None)` while the studio hasn't quoted yet (404).
+pub async fn poll_quote(
+    client_app: ClientApp,
+    rfq_url: &str,
+    rfq_id: &str,
+) -> Result<Option<serde_json::Value>> {
+    let client = reqwest::Client::builder()
+        .timeout(POLL_TIMEOUT)
+        .user_agent(client_app.user_agent())
+        .build()
+        .map_err(|e| Error::Config(format!("http client: {e}")))?;
+    let quote_url = format!("{}/{}/quote", rfq_url.trim_end_matches('/'), rfq_id);
+    let resp = client
+        .get(&quote_url)
+        .send()
+        .await
+        .map_err(|e| Error::Config(format!("fetch {quote_url}: {e}")))?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !resp.status().is_success() {
+        return Err(Error::Config(format!(
+            "{quote_url} returned {}",
+            resp.status()
+        )));
+    }
+    resp.json()
+        .await
+        .map(Some)
+        .map_err(|e| Error::Config(format!("parse {quote_url}: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_registry_has_scarce_entry() {
+        let registry = StudioRegistry::default();
+        assert_eq!(registry.studios.len(), 1);
+        assert_eq!(registry.studios[0].name, DEFAULT_STUDIO_NAME);
+        assert_eq!(registry.studios[0].rfq_url, DEFAULT_RFQ_URL);
+    }
+
+    #[test]
+    fn new_commission_omits_absent_optional_fields() {
+        let commission = NewCommission {
+            query: "solana priority fee forecast api".to_string(),
+            product: None,
+            monetization: None,
+            competition: vec![],
+            budget_ceiling: None,
+            buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
+                .to_string(),
+        };
+        let json = serde_json::to_value(&commission).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.contains_key("product"));
+        assert!(!obj.contains_key("monetization"));
+        assert!(!obj.contains_key("competition"));
+        assert!(!obj.contains_key("budget_ceiling"));
+        assert_eq!(obj["query"], "solana priority fee forecast api");
+    }
+
+    #[test]
+    fn new_commission_includes_present_optional_fields() {
+        let commission = NewCommission {
+            query: "q".to_string(),
+            product: Some("a live forecast endpoint".to_string()),
+            monetization: Some("per-call".to_string()),
+            competition: vec!["incumbent/api".to_string()],
+            budget_ceiling: Some(CommissionAmount {
+                amount: 10_000_000,
+                mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            }),
+            buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
+                .to_string(),
+        };
+        let json = serde_json::to_value(&commission).unwrap();
+        assert_eq!(json["product"], "a live forecast endpoint");
+        assert_eq!(json["competition"][0], "incumbent/api");
+        assert_eq!(json["budget_ceiling"]["amount"], 10_000_000);
+        assert_eq!(
+            json["budget_ceiling"]["mint"],
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
+    }
+}

--- a/rust/crates/core/src/studios/mod.rs
+++ b/rust/crates/core/src/studios/mod.rs
@@ -1,5 +1,5 @@
 //! Studio registry — v0 static config naming which studios receive RFQ
-//! fan-out from the MCP `commission_capability` tool (commission-flow
+//! fan-out from the MCP `request_capability` tool (commission-flow
 //! draft-00, concrete delta 3). One entry per studio; `~/.config/pay/studios.yaml`
 //! overrides the shipped default so a local `scarced` dev instance can stand
 //! in for the production endpoint during development.
@@ -24,7 +24,7 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct Studio {
     /// Display name (e.g. "scarce").
     pub name: String,
-    /// `POST` target that accepts the `NewCommission` wire body (mirrors
+    /// `POST` target that accepts the `NewCapabilityRequest` wire body (mirrors
     /// `scarce-studio`'s `studio-types::NewRfq` / `schemas/rfq.json`) and
     /// returns the captured RFQ record.
     pub rfq_url: String,
@@ -86,7 +86,7 @@ fn config_path() -> PathBuf {
 /// crate; a field mismatch surfaces as a 422 from the studio, which
 /// [`submit_to_registry`] reports verbatim rather than papering over.
 #[derive(Debug, Clone, Serialize)]
-pub struct NewCommission {
+pub struct NewCapabilityRequest {
     pub query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product: Option<String>,
@@ -95,17 +95,17 @@ pub struct NewCommission {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub competition: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub budget_ceiling: Option<CommissionAmount>,
+    pub budget_ceiling: Option<BudgetAmount>,
     pub buyer_npub: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct CommissionAmount {
+pub struct BudgetAmount {
     pub amount: u64,
     pub mint: String,
 }
 
-/// Outcome of POSTing a commission RFQ to one studio.
+/// Outcome of POSTing a capability-request RFQ to one studio.
 #[derive(Debug, Clone, Serialize)]
 pub struct StudioSubmission {
     pub studio: String,
@@ -116,13 +116,13 @@ pub struct StudioSubmission {
     pub error: Option<String>,
 }
 
-/// POST `commission` to every registered studio. Independent per studio —
+/// POST `request` to every registered studio. Independent per studio —
 /// one being unreachable or rejecting the submission never fails the
 /// others (commission-flow draft-00 step 3: "quotes return by deadline or
 /// silently decline").
 pub async fn submit_to_registry(
     registry: &StudioRegistry,
-    commission: &NewCommission,
+    request: &NewCapabilityRequest,
     client_app: ClientApp,
 ) -> Result<Vec<StudioSubmission>> {
     let client = reqwest::Client::builder()
@@ -133,7 +133,7 @@ pub async fn submit_to_registry(
 
     let mut submissions = Vec::with_capacity(registry.studios.len());
     for studio in &registry.studios {
-        submissions.push(submit_one(&client, studio, commission).await);
+        submissions.push(submit_one(&client, studio, request).await);
     }
     Ok(submissions)
 }
@@ -141,7 +141,7 @@ pub async fn submit_to_registry(
 async fn submit_one(
     client: &reqwest::Client,
     studio: &Studio,
-    commission: &NewCommission,
+    request: &NewCapabilityRequest,
 ) -> StudioSubmission {
     let base = StudioSubmission {
         studio: studio.name.clone(),
@@ -149,7 +149,7 @@ async fn submit_one(
         rfq: None,
         error: None,
     };
-    match client.post(&studio.rfq_url).json(commission).send().await {
+    match client.post(&studio.rfq_url).json(request).send().await {
         Ok(resp) if resp.status().is_success() => match resp.json::<serde_json::Value>().await {
             Ok(rfq) => StudioSubmission {
                 rfq: Some(rfq),
@@ -222,8 +222,8 @@ mod tests {
     }
 
     #[test]
-    fn new_commission_omits_absent_optional_fields() {
-        let commission = NewCommission {
+    fn new_capability_request_omits_absent_optional_fields() {
+        let request = NewCapabilityRequest {
             query: "solana priority fee forecast api".to_string(),
             product: None,
             monetization: None,
@@ -232,7 +232,7 @@ mod tests {
             buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
                 .to_string(),
         };
-        let json = serde_json::to_value(&commission).unwrap();
+        let json = serde_json::to_value(&request).unwrap();
         let obj = json.as_object().unwrap();
         assert!(!obj.contains_key("product"));
         assert!(!obj.contains_key("monetization"));
@@ -242,20 +242,20 @@ mod tests {
     }
 
     #[test]
-    fn new_commission_includes_present_optional_fields() {
-        let commission = NewCommission {
+    fn new_capability_request_includes_present_optional_fields() {
+        let request = NewCapabilityRequest {
             query: "q".to_string(),
             product: Some("a live forecast endpoint".to_string()),
             monetization: Some("per-call".to_string()),
             competition: vec!["incumbent/api".to_string()],
-            budget_ceiling: Some(CommissionAmount {
+            budget_ceiling: Some(BudgetAmount {
                 amount: 10_000_000,
                 mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
             }),
             buyer_npub: "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy"
                 .to_string(),
         };
-        let json = serde_json::to_value(&commission).unwrap();
+        let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["product"], "a live forecast endpoint");
         assert_eq!(json["competition"][0], "incumbent/api");
         assert_eq!(json["budget_ceiling"]["amount"], 10_000_000);

--- a/rust/crates/core/src/studios/mod.rs
+++ b/rust/crates/core/src/studios/mod.rs
@@ -4,9 +4,10 @@
 //! overrides the shipped default so a local `scarced` dev instance can stand
 //! in for the production endpoint during development.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{ClientApp, Error, Result};
@@ -50,29 +51,39 @@ impl Default for StudioRegistry {
 impl StudioRegistry {
     pub fn load() -> Result<Self> {
         let path = config_path();
-        if !path.exists()
-            || std::fs::read_to_string(&path)
-                .map(|raw| raw.trim().is_empty())
-                .unwrap_or(true)
-        {
+        Self::load_from_path(&path)
+    }
+
+    fn load_from_path(path: &Path) -> Result<Self> {
+        if !path.exists() {
             let cfg = Self::default();
-            let _ = cfg.save(); // persist so the user can see/edit it
+            cfg.save_to_path(path)?; // persist so the user can see/edit it
             return Ok(cfg);
         }
-        let raw = std::fs::read_to_string(&path)
+        let raw = std::fs::read_to_string(path)
             .map_err(|e| Error::Config(format!("read {}: {e}", path.display())))?;
+        if raw.trim().is_empty() {
+            return Err(Error::Config(format!(
+                "{} is empty; add at least one studio or remove the file to restore the default",
+                path.display()
+            )));
+        }
         serde_yml::from_str(&raw)
             .map_err(|e| Error::Config(format!("parse {}: {e}", path.display())))
     }
 
     pub fn save(&self) -> Result<()> {
         let path = config_path();
+        self.save_to_path(&path)
+    }
+
+    fn save_to_path(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| Error::Config(format!("mkdir: {e}")))?;
         }
         let yaml =
             serde_yml::to_string(self).map_err(|e| Error::Config(format!("serialize: {e}")))?;
-        std::fs::write(&path, yaml)
+        std::fs::write(path, yaml)
             .map_err(|e| Error::Config(format!("write {}: {e}", path.display())))
     }
 }
@@ -105,12 +116,132 @@ pub struct NewCapabilityRequest {
     /// Buyer identity, Solana side — the local Pay wallet's pubkey.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub buyer_solana_pubkey: Option<String>,
+    /// Quote-ready specification assembled and validated by the buyer-side
+    /// MRTR refinement loop. Studios receive this instead of doing unpaid
+    /// discovery work themselves.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub brief: Option<CapabilityBrief>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct BudgetAmount {
     pub amount: u64,
     pub mint: String,
+}
+
+/// Quote-sizing specification mirrored from scarce-studio's public RFQ schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CapabilityBrief {
+    pub example_exchange: ExampleExchange,
+    pub freshness: Freshness,
+    #[serde(default)]
+    pub upstream_dependencies: Vec<UpstreamDependency>,
+    pub volume: VolumeBand,
+    pub compute_class: ComputeClass,
+    pub state: StateRequirement,
+    pub interface: InterfaceKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExampleExchange {
+    pub request: serde_json::Value,
+    pub response: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Freshness {
+    Realtime,
+    Cached { ttl_seconds: u64 },
+    Scheduled { cron: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamDependency {
+    pub name: String,
+    #[serde(default)]
+    pub est_cost_per_call: Option<BudgetAmount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VolumeBand {
+    pub calls_per_month: u64,
+    pub avg_request_bytes: u64,
+    pub avg_response_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputeClass {
+    Proxy,
+    Cpu,
+    Gpu,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StateRequirement {
+    None,
+    Cache,
+    Durable { gib: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InterfaceKind {
+    RequestResponse,
+    WebhookPush,
+    Dataset,
+}
+
+impl CapabilityBrief {
+    /// Collect every actionable semantic error so the refinement model can
+    /// correct the brief in one MRTR round.
+    pub fn validation_errors(&self) -> Vec<String> {
+        let mut errors = Vec::new();
+        match &self.freshness {
+            Freshness::Cached { ttl_seconds } if *ttl_seconds == 0 => {
+                errors.push("brief.freshness.ttl_seconds must be at least 1".to_string());
+            }
+            Freshness::Scheduled { cron } if cron.trim().is_empty() => {
+                errors.push("brief.freshness.cron must be a non-empty cron expression".to_string());
+            }
+            _ => {}
+        }
+        for (index, dependency) in self.upstream_dependencies.iter().enumerate() {
+            if dependency.name.trim().is_empty() {
+                errors.push(format!(
+                    "brief.upstream_dependencies[{index}].name must be non-empty"
+                ));
+            }
+            if let Some(cost) = &dependency.est_cost_per_call {
+                if cost.amount == 0 {
+                    errors.push(format!(
+                        "brief.upstream_dependencies[{index}].est_cost_per_call.amount must be greater than zero"
+                    ));
+                }
+                if cost.mint.trim().is_empty() {
+                    errors.push(format!(
+                        "brief.upstream_dependencies[{index}].est_cost_per_call.mint must be non-empty"
+                    ));
+                }
+            }
+        }
+        if self.volume.calls_per_month == 0 {
+            errors.push("brief.volume.calls_per_month must be at least 1".to_string());
+        }
+        if let StateRequirement::Durable { gib } = self.state
+            && gib == 0
+        {
+            errors.push("brief.state.gib must be at least 1".to_string());
+        }
+        errors
+    }
 }
 
 /// Outcome of POSTing a capability-request RFQ to one studio.
@@ -230,6 +361,25 @@ mod tests {
     }
 
     #[test]
+    fn unreadable_registry_fails_closed_instead_of_using_default() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("studios.yaml");
+        std::fs::create_dir(&path).unwrap();
+        let error = StudioRegistry::load_from_path(&path).unwrap_err();
+        assert!(error.to_string().contains("read"));
+    }
+
+    #[test]
+    fn empty_registry_file_is_actionable_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("studios.yaml");
+        std::fs::write(&path, "  \n").unwrap();
+        let error = StudioRegistry::load_from_path(&path).unwrap_err();
+        assert!(error.to_string().contains("is empty"));
+        assert!(error.to_string().contains("remove the file"));
+    }
+
+    #[test]
     fn new_capability_request_omits_absent_optional_fields() {
         let request = NewCapabilityRequest {
             query: "solana priority fee forecast api".to_string(),
@@ -239,6 +389,7 @@ mod tests {
             budget_ceiling: None,
             buyer_npub: None,
             buyer_solana_pubkey: Some("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T".to_string()),
+            brief: None,
         };
         let json = serde_json::to_value(&request).unwrap();
         let obj = json.as_object().unwrap();
@@ -272,6 +423,7 @@ mod tests {
                 "npub1cscv4empnwmfyurd6utlwmq3h3dzpesjyhtttt6rk69hndk9w0nqr65xpy".to_string(),
             ),
             buyer_solana_pubkey: None,
+            brief: None,
         };
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(

--- a/rust/crates/mcp/Cargo.toml
+++ b/rust/crates/mcp/Cargo.toml
@@ -18,8 +18,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 rmcp = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
-schemars = { workspace = true }
+schemars = "1"
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -28,5 +29,5 @@ tracing-subscriber = { workspace = true }
 # E2E tests pair the pay-mcp server with an in-process rmcp client over a
 # duplex transport. The `client` feature is only needed for tests; pulling
 # it in here keeps the production build lean.
-rmcp = { version = "0.9", features = ["server", "transport-io", "elicitation", "schemars", "client"] }
+rmcp = { version = "3.1", features = ["server", "transport-io", "elicitation", "schemars", "request-state", "client"] }
 tempfile = { workspace = true }

--- a/rust/crates/mcp/src/auth.rs
+++ b/rust/crates/mcp/src/auth.rs
@@ -14,13 +14,11 @@
 //! the MCP client anyway.
 //!
 //! The [`AuthGate`] trait is synchronous, but rmcp's elicitation call is
-//! `async`. We bridge with [`tokio::task::block_in_place`] + the current
-//! [`tokio::runtime::Handle`] — the entire pay-mcp server runs on a
-//! multi-threaded Tokio runtime, so the calling thread can yield to the
-//! runtime while we wait on the elicitation round-trip. This is the same
-//! shape that platform gates already use (Touch ID is also a blocking
-//! "wait for a human" call from Rust's view; the difference is purely
-//! plumbing).
+//! `async`. Payment work runs on a blocking thread and sends approval requests
+//! through a broker polled by the original tool-handler task. That preserves
+//! MCP 2026-07-28 request association (SEP-2260) while the blocking signer
+//! waits just like a native Touch ID prompt. The direct peer backend remains
+//! for older MCP sessions and compatibility tests.
 //!
 //! All failure modes map to [`pay_keystore::Error::AuthDenied`]: declined
 //! responses, cancelled responses, transport errors, and timeouts. The
@@ -30,11 +28,9 @@ use std::time::Duration;
 
 use pay_keystore::{AuthGate, AuthIntent, Error as KeystoreError};
 use rmcp::Peer;
-use rmcp::model::{
-    CreateElicitationRequestParam, CreateElicitationResult, ElicitationAction, ElicitationSchema,
-};
+use rmcp::model::{ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema};
 use rmcp::service::RoleServer;
-use tokio::runtime::Handle;
+use tokio::sync::mpsc;
 
 /// Outer deadline for a single elicitation round-trip, including the
 /// human's response time. Matches Hermes' gateway approval default so
@@ -75,46 +71,69 @@ pub async fn confirm_file_upload(
         }
         ElicitationAction::Decline => Err("The user declined to send the local file.".to_string()),
         ElicitationAction::Cancel => Err("The user cancelled sending the local file.".to_string()),
+        _ => Err("The MCP client returned an unsupported approval action.".to_string()),
     }
 }
 
 /// `AuthGate` that asks the connected MCP client for approval via
 /// `elicitation/create` instead of a platform biometric prompt.
 pub struct ElicitationAuth {
-    peer: Peer<RoleServer>,
+    backend: ElicitationBackend,
+}
+
+enum ElicitationBackend {
+    Direct(Peer<RoleServer>),
+    Broker(mpsc::UnboundedSender<BrokerRequest>),
+}
+
+pub(crate) struct BrokerRequest {
+    params: ElicitRequestParams,
+    reply: std::sync::mpsc::SyncSender<Result<ElicitResult, rmcp::ServiceError>>,
 }
 
 impl ElicitationAuth {
-    /// Construct a new gate bound to the active MCP session's peer.
+    /// Construct a direct gate for MCP sessions older than 2026-07-28.
     ///
-    /// The peer is cheap to clone — it holds an inner `Arc` — so callers
-    /// usually take a clone out of the rmcp tool-call context and hand it
-    /// here per signing operation.
+    /// MCP 2026-07-28 requires request association; Pay's tool handler uses
+    /// the internal broker backend for those sessions.
     pub fn new(peer: Peer<RoleServer>) -> Self {
-        Self { peer }
+        Self {
+            backend: ElicitationBackend::Direct(peer),
+        }
+    }
+
+    pub(crate) fn via_broker(sender: mpsc::UnboundedSender<BrokerRequest>) -> Self {
+        Self {
+            backend: ElicitationBackend::Broker(sender),
+        }
     }
 }
 
 impl AuthGate for ElicitationAuth {
     fn authenticate(&self, intent: &AuthIntent) -> Result<(), KeystoreError> {
         let params = build_request(intent);
-        let peer = self.peer.clone();
-
-        // Bridge sync → async. `block_in_place` permits blocking on the
-        // current multi-threaded runtime worker without starving other
-        // tasks; `Handle::current().block_on` drives the elicitation
-        // future to completion. Equivalent to how the macOS Touch ID
-        // gate blocks the calling thread on `LAContext.evaluatePolicy`.
-        let outcome: Result<CreateElicitationResult, rmcp::ServiceError> =
-            tokio::task::block_in_place(|| {
-                Handle::current().block_on(async move {
-                    tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
-                        .await
-                        .map_err(|_| rmcp::ServiceError::Timeout {
-                            timeout: ELICITATION_TIMEOUT,
-                        })?
+        let outcome = match &self.backend {
+            ElicitationBackend::Direct(peer) => {
+                let peer = peer.clone();
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(request_elicitation(&peer, params))
                 })
-            });
+            }
+            ElicitationBackend::Broker(sender) => {
+                let (reply, response) = std::sync::mpsc::sync_channel(1);
+                if sender.send(BrokerRequest { params, reply }).is_err() {
+                    Err(rmcp::ServiceError::TransportClosed)
+                } else {
+                    response
+                        .recv_timeout(ELICITATION_TIMEOUT)
+                        .unwrap_or_else(|_| {
+                            Err(rmcp::ServiceError::Timeout {
+                                timeout: ELICITATION_TIMEOUT,
+                            })
+                        })
+                }
+            }
+        };
 
         interpret_elicitation_outcome(outcome)
     }
@@ -124,6 +143,44 @@ impl AuthGate for ElicitationAuth {
         // transport failure as AuthDenied anyway, and is_available() is
         // called from contexts where blocking is undesirable.
         true
+    }
+}
+
+async fn request_elicitation(
+    peer: &Peer<RoleServer>,
+    params: ElicitRequestParams,
+) -> Result<ElicitResult, rmcp::ServiceError> {
+    tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
+        .await
+        .map_err(|_| rmcp::ServiceError::Timeout {
+            timeout: ELICITATION_TIMEOUT,
+        })?
+}
+
+/// Run blocking payment work while servicing its approval requests on the
+/// originating MCP task. MCP 2026-07-28 requires this association (SEP-2260),
+/// so the blocking signer never calls the peer directly.
+pub(crate) async fn spawn_blocking_with_elicitation<T, F>(
+    peer: &Peer<RoleServer>,
+    operation: F,
+) -> Result<T, tokio::task::JoinError>
+where
+    T: Send + 'static,
+    F: FnOnce(mpsc::UnboundedSender<BrokerRequest>) -> T + Send + 'static,
+{
+    let (sender, mut requests) = mpsc::unbounded_channel();
+    let mut operation = tokio::task::spawn_blocking(move || operation(sender));
+    loop {
+        tokio::select! {
+            result = &mut operation => return result,
+            request = requests.recv() => {
+                let Some(request) = request else {
+                    return operation.await;
+                };
+                let result = request_elicitation(peer, request.params).await;
+                let _ = request.reply.send(result);
+            }
+        }
     }
 }
 
@@ -142,7 +199,7 @@ impl AuthGate for ElicitationAuth {
 /// with a negative answer), but a buggy or hostile client might — and we'd
 /// rather deny than admit on conflicting input.
 fn interpret_elicitation_outcome(
-    outcome: Result<CreateElicitationResult, rmcp::ServiceError>,
+    outcome: Result<ElicitResult, rmcp::ServiceError>,
 ) -> Result<(), KeystoreError> {
     match outcome {
         Ok(res) => match res.action {
@@ -167,6 +224,9 @@ fn interpret_elicitation_outcome(
             ElicitationAction::Cancel => Err(KeystoreError::AuthDenied(
                 "user cancelled the request via the MCP client".to_string(),
             )),
+            _ => Err(KeystoreError::AuthDenied(
+                "MCP client returned an unsupported elicitation action".to_string(),
+            )),
         },
         Err(err) => Err(KeystoreError::AuthDenied(format!(
             "elicitation transport failed: {err}"
@@ -181,7 +241,7 @@ fn interpret_elicitation_outcome(
 ///   so clients that render forms can present a confirmation UI; clients
 ///   that fall back to yes/no still get the message text.
 /// - **Per-call only**: no server-side state binds approvals across calls.
-fn build_request(intent: &AuthIntent) -> CreateElicitationRequestParam {
+fn build_request(intent: &AuthIntent) -> ElicitRequestParams {
     // Builder validates required fields against declared properties.
     // The combination below is statically sound; `expect` would only
     // fire if rmcp's validation contract changes in a future release.
@@ -190,7 +250,8 @@ fn build_request(intent: &AuthIntent) -> CreateElicitationRequestParam {
         .build()
         .expect("required_bool registers `approved` in properties");
 
-    CreateElicitationRequestParam {
+    ElicitRequestParams::FormElicitationParams {
+        meta: None,
         message: intent.message().to_string(),
         requested_schema: schema,
     }
@@ -201,12 +262,13 @@ fn build_file_upload_request(
     bytes: u64,
     method: &str,
     destination: &str,
-) -> CreateElicitationRequestParam {
+) -> ElicitRequestParams {
     let schema = ElicitationSchema::builder()
         .required_bool("approved")
         .build()
         .expect("required_bool registers `approved` in properties");
-    CreateElicitationRequestParam {
+    ElicitRequestParams::FormElicitationParams {
+        meta: None,
         message: format!(
             "Allow Pay to read and send `{path}` ({bytes} bytes) in an HTTP {method} request to {destination}? The file is read once after approval; the exact snapshot may be reused only to retry this same request after a 402 payment challenge."
         ),
@@ -218,19 +280,29 @@ fn build_file_upload_request(
 mod tests {
     use super::*;
 
+    fn form(request: &ElicitRequestParams) -> (&str, &ElicitationSchema) {
+        match request {
+            ElicitRequestParams::FormElicitationParams {
+                message,
+                requested_schema,
+                ..
+            } => (message, requested_schema),
+            _ => panic!("expected form elicitation"),
+        }
+    }
+
     #[test]
     fn build_request_carries_intent_message() {
         let intent = AuthIntent::authorize_payment("$0.50", "accessing API api.example.com");
         let req = build_request(&intent);
+        let (message, _) = form(&req);
         assert!(
-            req.message.contains("$0.50"),
-            "message should include amount: {:?}",
-            req.message,
+            message.contains("$0.50"),
+            "message should include amount: {message:?}",
         );
         assert!(
-            req.message.contains("api.example.com"),
-            "message should include operator: {:?}",
-            req.message,
+            message.contains("api.example.com"),
+            "message should include operator: {message:?}",
         );
     }
 
@@ -238,9 +310,10 @@ mod tests {
     fn build_request_includes_approved_boolean_field() {
         let intent = AuthIntent::default_payment();
         let req = build_request(&intent);
+        let (_, schema) = form(&req);
         // The schema must include an `approved` property so even
         // form-rendering clients have a concrete confirmation field.
-        let json = serde_json::to_value(&req.requested_schema).expect("schema should serialize");
+        let json = serde_json::to_value(schema).expect("schema should serialize");
         let props = json.get("properties").expect("schema has properties");
         assert!(
             props.get("approved").is_some(),
@@ -256,17 +329,19 @@ mod tests {
             "POST",
             "https://api.example.com/upload",
         );
-        assert!(req.message.contains("/workspace/photo.png"));
-        assert!(req.message.contains("1024 bytes"));
-        assert!(req.message.contains("POST"));
-        assert!(req.message.contains("https://api.example.com/upload"));
+        let (message, _) = form(&req);
+        assert!(message.contains("/workspace/photo.png"));
+        assert!(message.contains("1024 bytes"));
+        assert!(message.contains("POST"));
+        assert!(message.contains("https://api.example.com/upload"));
     }
 
-    fn result(
-        action: ElicitationAction,
-        content: Option<serde_json::Value>,
-    ) -> CreateElicitationResult {
-        CreateElicitationResult { action, content }
+    fn result(action: ElicitationAction, content: Option<serde_json::Value>) -> ElicitResult {
+        let result = ElicitResult::new(action);
+        match content {
+            Some(content) => result.with_content(content),
+            None => result,
+        }
     }
 
     #[test]
@@ -320,5 +395,22 @@ mod tests {
             timeout: Duration::from_secs(1),
         }));
         assert!(matches!(out, Err(KeystoreError::AuthDenied(_))));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn broker_bridges_blocking_auth_to_async_approval() {
+        let (sender, mut requests) = mpsc::unbounded_channel();
+        let auth = ElicitationAuth::via_broker(sender);
+        let intent = AuthIntent::authorize_payment("$0.01", "broker test");
+        let operation = tokio::task::spawn_blocking(move || auth.authenticate(&intent));
+
+        let request = requests.recv().await.expect("broker request");
+        request
+            .reply
+            .send(Ok(ElicitResult::new(ElicitationAction::Accept)
+                .with_content(serde_json::json!({ "approved": true }))))
+            .unwrap();
+
+        assert!(operation.await.unwrap().is_ok());
     }
 }

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -77,13 +77,14 @@ fields, and the next provider-selection step. Select an endpoint only when it
 clearly matches the task; otherwise inspect one likely provider with
 `get_catalog_entry` or ask the user.
 
-On a real miss (no candidates), this tool itself elicits the user for
-consent to submit a capability request to the studio registry, and on accept
-runs the same brief-interview and submission flow as `request_capability`
-before returning. If the connected client doesn't support elicitation, the
-response falls back to a text hint naming `request_capability` instead. You
-never need to call `request_capability` yourself right after an empty
-`search_catalog` result — it has already been offered.
+On a real miss (no candidate clearly fits — weak keyword matches may still be
+listed), this tool itself asks the user — one prompt, accept-to-send — whether
+to have the studio registry build the capability, and on accept runs the same
+submission flow as `request_capability` before returning. If the connected
+client doesn't support elicitation, the response falls back to a text hint
+naming `request_capability` instead. You never need to call
+`request_capability` yourself right after a missed `search_catalog` — it has
+already been offered.
 "#
     )]
     async fn search_catalog(
@@ -106,6 +107,11 @@ service list with use cases. For actionable execution after capability is
 established, call `search_catalog` with the user's task. When the user asks what
 Pay can do, present the catalog grouped by category so they can scan available
 APIs/skills.
+
+If the catalog does NOT cover the user's need, do not stop at "no": call
+`search_catalog` with the user's real task. On a miss it offers (via user
+consent) a capability request to the studio registry, so the unmet need is
+recorded instead of dead-ending.
 "#)]
     async fn list_catalog(
         &self,
@@ -188,16 +194,18 @@ For detailed authoring guidance, use the Pay skill reference
     #[tool(
         description = r#"Ask the studio registry to build a capability Pay doesn't have yet.
 
-`search_catalog` already offers this automatically on a real miss (empty
-candidates) via its own consent elicitation — do not call this speculatively
-right after an empty search just because it returned nothing. Call it
-directly only when the user asks to request/commission a capability outright,
-without having just run `search_catalog`, or after a client that can't
-elicit reported a miss. The tool itself asks for explicit consent before
-doing anything (an elicitation round-trip), then asks a short set of
-questions about what to build, then submits the request to every registered
-studio and reports back either a quote or that the request is pending.
-This never spends funds; accepting and funding a quote is a separate step.
+`search_catalog` offers this automatically on a clear miss — when its
+response already contains a `capability_request`, the user has been asked;
+do not call this again for the same query. In every other uncovered case,
+call it: search returned only weak keyword matches that don't actually do
+the user's task, `list_catalog` showed nothing fitting, or the user asks to
+have something built. The tool shows a single accept-to-send prompt
+(optional details and budget) and that prompt itself is the consent gate,
+so calling it on a suspected miss is safe — declining costs nothing and
+submits nothing. On accept it attributes the request to the user's Pay
+wallet, submits it to every registered studio, and reports back either a
+quote or that the request is pending. This never spends funds; accepting
+and funding a quote is a separate step.
 "#
     )]
     async fn request_capability(

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -17,6 +17,7 @@ pub struct PayMcp {
     #[allow(dead_code)]
     tool_router: rmcp::handler::server::router::tool::ToolRouter<Self>,
     capability_mrtr: tools::request_capability::MrtrState,
+    payment_sessions: pay_core::session_manager::SessionManager,
 }
 
 impl Default for PayMcp {
@@ -31,6 +32,7 @@ impl PayMcp {
         Self {
             tool_router: Self::tool_router(),
             capability_mrtr: tools::request_capability::MrtrState::default(),
+            payment_sessions: pay_core::session_manager::SessionManager::default(),
         }
     }
 
@@ -67,7 +69,7 @@ and does not submit the request or payment.
         Parameters(params): Parameters<tools::curl::Params>,
         peer: rmcp::Peer<rmcp::service::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::curl::run(params, peer).await
+        tools::curl::run(params, peer, self.payment_sessions.clone()).await
     }
 
     #[tool(

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -92,8 +92,9 @@ prompt is the consent step).
         &self,
         Parameters(params): Parameters<tools::search_catalog::Params>,
         peer: rmcp::Peer<rmcp::service::RoleServer>,
+        meta: rmcp::model::Meta,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::search_catalog::run(params, peer).await
+        tools::search_catalog::run(params, peer, meta.get_progress_token()).await
     }
 
     #[tool(description = r#"List all available Pay APIs/skills.
@@ -203,24 +204,25 @@ do not call this again for the same query. In every other uncovered case,
 call it directly: search returned only weak keyword matches that don't
 actually do the user's task, `list_catalog` showed nothing fitting, or the
 user asks to have something built. NEVER pre-ask for permission in chat —
-the tool's single accept-to-send prompt (optional details and budget) IS
-the consent step, so a chat-level ask is a duplicate; calling on a
-suspected miss is safe because declining costs nothing and submits
-nothing. When you talk about it, frame it as what it is: the user found
-unmet demand, a studio builds and deploys the API, and the user publishes
-and monetizes it — an agentic business opportunity, not paperwork. On
-accept it attributes the request to the user's Pay wallet, submits it to
-every registered studio, and reports back either a quote or that the
-request is pending. This never spends funds; accepting and funding a quote
-is a separate step.
+the tool's single accept-to-send prompt (two optional free-form questions:
+what to build, what they'd use today) IS the consent step, so a chat-level
+ask is a duplicate; calling on a suspected miss is safe because declining
+costs nothing and submits nothing. When you talk about it, frame it as
+what it is: the user found unmet demand, a studio builds and deploys the
+API, and the user publishes and monetizes it — an agentic business
+opportunity, not paperwork. On accept the answers are structured into a
+brief and the request is attributed to the user's Pay wallet, submitted to
+every registered studio, and reported back as either a quote or pending.
+This never spends funds; accepting and funding a quote is a separate step.
 "#
     )]
     async fn request_capability(
         &self,
         Parameters(params): Parameters<tools::request_capability::Params>,
         peer: rmcp::Peer<rmcp::service::RoleServer>,
+        meta: rmcp::model::Meta,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::request_capability::run(params, peer).await
+        tools::request_capability::run(params, peer, meta.get_progress_token()).await
     }
 }
 

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -76,13 +76,22 @@ includes reasons, endpoint/pricing candidates, tie-breaker guidance, call-plan
 fields, and the next provider-selection step. Select an endpoint only when it
 clearly matches the task; otherwise inspect one likely provider with
 `get_catalog_entry` or ask the user.
+
+On a real miss (no candidates), this tool itself elicits the user for
+consent to submit a capability request to the studio registry, and on accept
+runs the same brief-interview and submission flow as `request_capability`
+before returning. If the connected client doesn't support elicitation, the
+response falls back to a text hint naming `request_capability` instead. You
+never need to call `request_capability` yourself right after an empty
+`search_catalog` result — it has already been offered.
 "#
     )]
     async fn search_catalog(
         &self,
         Parameters(params): Parameters<tools::search_catalog::Params>,
+        peer: rmcp::Peer<rmcp::service::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::search_catalog::run(params).await
+        tools::search_catalog::run(params, peer).await
     }
 
     #[tool(description = r#"List all available Pay APIs/skills.
@@ -179,10 +188,12 @@ For detailed authoring guidance, use the Pay skill reference
     #[tool(
         description = r#"Ask the studio registry to build a capability Pay doesn't have yet.
 
-Only call this after `search_catalog` returns no usable candidate for an
-actionable task, and only when the user actually wants a new provider
-requested — never speculatively, and never automatically just because a
-search came back empty. The tool itself asks for explicit consent before
+`search_catalog` already offers this automatically on a real miss (empty
+candidates) via its own consent elicitation — do not call this speculatively
+right after an empty search just because it returned nothing. Call it
+directly only when the user asks to request/commission a capability outright,
+without having just run `search_catalog`, or after a client that can't
+elicit reported a miss. The tool itself asks for explicit consent before
 doing anything (an elicitation round-trip), then asks a short set of
 questions about what to build, then submits the request to every registered
 studio and reports back either a quote or that the request is pending.

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -80,11 +80,12 @@ clearly matches the task; otherwise inspect one likely provider with
 On a real miss (no candidate clearly fits — weak keyword matches may still be
 listed), this tool itself asks the user — one prompt, accept-to-send — whether
 to have the studio registry build the capability, and on accept runs the same
-submission flow as `request_capability` before returning. If the connected
-client doesn't support elicitation, the response falls back to a text hint
-naming `request_capability` instead. You never need to call
-`request_capability` yourself right after a missed `search_catalog` — it has
-already been offered.
+submission flow as `request_capability` before returning. When the response
+contains a `capability_request`, the user has already been asked — do not ask
+again in chat and do not call `request_capability` for the same query.
+Otherwise follow the response's `next_step`: it says when to call
+`request_capability` directly (call it without pre-asking in chat — its own
+prompt is the consent step).
 "#
     )]
     async fn search_catalog(
@@ -109,9 +110,11 @@ Pay can do, present the catalog grouped by category so they can scan available
 APIs/skills.
 
 If the catalog does NOT cover the user's need, do not stop at "no": call
-`search_catalog` with the user's real task. On a miss it offers (via user
-consent) a capability request to the studio registry, so the unmet need is
-recorded instead of dead-ending.
+`search_catalog` with the user's real task. On a miss it prompts the user
+itself (never pre-ask in chat) with an offer to have the capability built
+by the studio registry — a gap in the catalog is an opportunity for the
+user to get an API built, published, and monetized under them, so present
+it that way instead of dead-ending at "no".
 "#)]
     async fn list_catalog(
         &self,
@@ -197,15 +200,19 @@ For detailed authoring guidance, use the Pay skill reference
 `search_catalog` offers this automatically on a clear miss — when its
 response already contains a `capability_request`, the user has been asked;
 do not call this again for the same query. In every other uncovered case,
-call it: search returned only weak keyword matches that don't actually do
-the user's task, `list_catalog` showed nothing fitting, or the user asks to
-have something built. The tool shows a single accept-to-send prompt
-(optional details and budget) and that prompt itself is the consent gate,
-so calling it on a suspected miss is safe — declining costs nothing and
-submits nothing. On accept it attributes the request to the user's Pay
-wallet, submits it to every registered studio, and reports back either a
-quote or that the request is pending. This never spends funds; accepting
-and funding a quote is a separate step.
+call it directly: search returned only weak keyword matches that don't
+actually do the user's task, `list_catalog` showed nothing fitting, or the
+user asks to have something built. NEVER pre-ask for permission in chat —
+the tool's single accept-to-send prompt (optional details and budget) IS
+the consent step, so a chat-level ask is a duplicate; calling on a
+suspected miss is safe because declining costs nothing and submits
+nothing. When you talk about it, frame it as what it is: the user found
+unmet demand, a studio builds and deploys the API, and the user publishes
+and monetizes it — an agentic business opportunity, not paperwork. On
+accept it attributes the request to the user's Pay wallet, submits it to
+every registered studio, and reports back either a quote or that the
+request is pending. This never spends funds; accepting and funding a quote
+is a separate step.
 "#
     )]
     async fn request_capability(

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -180,8 +180,8 @@ For detailed authoring guidance, use the Pay skill reference
         description = r#"Ask the studio registry to build a capability Pay doesn't have yet.
 
 Only call this after `search_catalog` returns no usable candidate for an
-actionable task, and only when the user actually wants to commission a new
-provider — never speculatively, and never automatically just because a
+actionable task, and only when the user actually wants a new provider
+requested — never speculatively, and never automatically just because a
 search came back empty. The tool itself asks for explicit consent before
 doing anything (an elicitation round-trip), then asks a short set of
 questions about what to build, then submits the request to every registered
@@ -189,12 +189,12 @@ studio and reports back either a quote or that the request is pending.
 This never spends funds; accepting and funding a quote is a separate step.
 "#
     )]
-    async fn commission_capability(
+    async fn request_capability(
         &self,
-        Parameters(params): Parameters<tools::commission_capability::Params>,
+        Parameters(params): Parameters<tools::request_capability::Params>,
         peer: rmcp::Peer<rmcp::service::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::commission_capability::run(params, peer).await
+        tools::request_capability::run(params, peer).await
     }
 }
 

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -2,15 +2,21 @@
 //!
 //! Each tool's logic and params live in `tools/<name>.rs`.
 
+use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ProtocolVersion, ServerCapabilities, ServerInfo};
-use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ListToolsResult,
+    PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::{ServerHandler, tool, tool_router};
 
 use crate::tools;
 
 pub struct PayMcp {
     #[allow(dead_code)]
     tool_router: rmcp::handler::server::router::tool::ToolRouter<Self>,
+    capability_mrtr: tools::request_capability::MrtrState,
 }
 
 impl Default for PayMcp {
@@ -24,6 +30,7 @@ impl PayMcp {
     pub fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            capability_mrtr: tools::request_capability::MrtrState::default(),
         }
     }
 
@@ -77,24 +84,20 @@ fields, and the next provider-selection step. Select an endpoint only when it
 clearly matches the task; otherwise inspect one likely provider with
 `get_catalog_entry` or ask the user.
 
-On a real miss (no candidate clearly fits — weak keyword matches may still be
-listed), this tool itself asks the user — one prompt, accept-to-send — whether
-to have the studio registry build the capability, and on accept runs the same
-submission flow as `request_capability` before returning. When the response
-contains a `capability_request`, the user has already been asked — do not ask
-again in chat and do not call `request_capability` for the same query.
-Otherwise follow the response's `next_step`: it says when to call
-`request_capability` directly (call it without pre-asking in chat — its own
-prompt is the consent step).
+On a measured miss (no candidate clearly fits — weak keyword matches may still
+be listed), this same tool call enters a resumable MRTR flow: one user prompt,
+then local-model refinement with read-only catalog research, strict validation,
+and quote-ready studio submission. Do not pre-ask in chat and do not call
+`request_capability` afterward for the same query. If the MCP client cannot run
+MRTR, the ordinary search result explains the unsupported flow and nothing is
+sent to a studio.
 "#
     )]
     async fn search_catalog(
         &self,
         Parameters(params): Parameters<tools::search_catalog::Params>,
-        peer: rmcp::Peer<rmcp::service::RoleServer>,
-        meta: rmcp::model::Meta,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::search_catalog::run(params, peer, meta.get_progress_token()).await
+        tools::search_catalog::run(params).await
     }
 
     #[tool(description = r#"List all available Pay APIs/skills.
@@ -198,44 +201,118 @@ For detailed authoring guidance, use the Pay skill reference
     #[tool(
         description = r#"Ask the studio registry to build a capability Pay doesn't have yet.
 
-`search_catalog` offers this automatically on a clear miss — when its
-response already contains a `capability_request`, the user has been asked;
-do not call this again for the same query. In every other uncovered case,
-call it directly: search returned only weak keyword matches that don't
-actually do the user's task, `list_catalog` showed nothing fitting, or the
-user asks to have something built. NEVER pre-ask for permission in chat —
-the tool's single accept-to-send prompt (two optional free-form questions:
-what to build, what they'd use today) IS the consent step, so a chat-level
-ask is a duplicate; calling on a suspected miss is safe because declining
-costs nothing and submits nothing. When you talk about it, frame it as
-what it is: the user found unmet demand, a studio builds and deploys the
-API, and the user publishes and monetizes it — an agentic business
-opportunity, not paperwork. On accept the answers are structured into a
-brief and the request is attributed to the user's Pay wallet, submitted to
-every registered studio, and reported back as either a quote or pending.
-This never spends funds; accepting and funding a quote is a separate step.
+`search_catalog` starts this automatically on a measured miss; do not call it
+again for the same query. In every other uncovered case, call it directly:
+search returned weak matches that do not perform the task, `list_catalog`
+showed nothing fitting, or the user asks to have something built. NEVER pre-ask
+for permission in chat. This one resumable MCP call owns the consent prompt,
+local-model research with read-only Pay catalog tools, strict quote-ready brief
+validation, and studio submission. There is no second tool call for the model
+to remember. Calling on a suspected miss is safe because declining costs
+nothing and submits nothing; invalid or incomplete refinement fails closed.
+Frame the offer as unmet demand the user can own and monetize, not paperwork.
+The request is attributed to the user's Pay wallet and reported as quoted,
+pending, or failed. This never spends funds; accepting and funding a quote is
+a separate step. Requires MCP 2026-07-28 MRTR, form elicitation, and
+sampling-with-tools.
 "#
     )]
     async fn request_capability(
         &self,
-        Parameters(params): Parameters<tools::request_capability::Params>,
-        peer: rmcp::Peer<rmcp::service::RoleServer>,
-        meta: rmcp::model::Meta,
+        Parameters(_params): Parameters<tools::request_capability::Params>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::request_capability::run(params, peer, meta.get_progress_token()).await
+        Ok(tools::tool_error(
+            "request_capability requires MCP 2026-07-28 multi-round-trip request support",
+        ))
     }
 }
 
-#[tool_handler]
 impl ServerHandler for PayMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2025_06_18,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: rmcp::model::Implementation::from_build_env(),
-            instructions: Some(pay_core::instructions::INSTRUCTIONS.to_string()),
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2026_07_28)
+            .with_instructions(pay_core::instructions::INSTRUCTIONS)
     }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, rmcp::ErrorData> {
+        let capability_flow = request.name == "request_capability"
+            || (request.name == "search_catalog" && request.request_state.is_some());
+        if capability_flow {
+            let supported = supports_capability_mrtr(&context);
+            if !supported {
+                return Ok(tools::tool_error(
+                    "request_capability requires MCP 2026-07-28 with form elicitation and sampling-with-tools. Nothing was sent to a studio.",
+                )
+                .into());
+            }
+            return tools::request_capability::run_mrtr(
+                request,
+                context.peer,
+                &self.capability_mrtr,
+            )
+            .await;
+        }
+
+        if request.name == "search_catalog" {
+            let params = match serde_json::from_value::<tools::search_catalog::Params>(
+                serde_json::Value::Object(request.arguments.clone().unwrap_or_default()),
+            ) {
+                Ok(params) => params,
+                Err(error) => {
+                    return Ok(tools::tool_error(format!(
+                        "Invalid search_catalog parameters: {error}"
+                    ))
+                    .into());
+                }
+            };
+            let (result, miss) = tools::search_catalog::run_with_miss(params).await?;
+            if !miss {
+                return Ok(result.into());
+            }
+            let supported = supports_capability_mrtr(&context);
+            if !supported {
+                return Ok(result.into());
+            }
+            return tools::request_capability::run_mrtr(
+                request,
+                context.peer,
+                &self.capability_mrtr,
+            )
+            .await;
+        }
+
+        self.tool_router
+            .call(ToolCallContext::new(self, request, context))
+            .await
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, rmcp::ErrorData> {
+        Ok(ListToolsResult::with_all_items(self.tool_router.list_all()))
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        self.tool_router.get(name).cloned()
+    }
+}
+
+fn supports_capability_mrtr(context: &RequestContext<RoleServer>) -> bool {
+    context.protocol_version() == Some(ProtocolVersion::V_2026_07_28)
+        && context.client_capabilities().is_some_and(|capabilities| {
+            capabilities
+                .elicitation
+                .is_some_and(|elicitation| elicitation.form.is_some())
+                && capabilities
+                    .sampling
+                    .is_some_and(|sampling| sampling.tools.is_some())
+        })
 }
 
 #[cfg(test)]
@@ -261,7 +338,7 @@ mod tests {
     fn server_info_protocol_version() {
         let mcp = PayMcp::new();
         let info = mcp.get_info();
-        assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2026_07_28);
     }
 
     #[test]

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -175,6 +175,27 @@ For detailed authoring guidance, use the Pay skill reference
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         tools::create_skill::run(params).await
     }
+
+    #[tool(
+        description = r#"Ask the studio registry to build a capability Pay doesn't have yet.
+
+Only call this after `search_catalog` returns no usable candidate for an
+actionable task, and only when the user actually wants to commission a new
+provider — never speculatively, and never automatically just because a
+search came back empty. The tool itself asks for explicit consent before
+doing anything (an elicitation round-trip), then asks a short set of
+questions about what to build, then submits the request to every registered
+studio and reports back either a quote or that the request is pending.
+This never spends funds; accepting and funding a quote is a separate step.
+"#
+    )]
+    async fn commission_capability(
+        &self,
+        Parameters(params): Parameters<tools::commission_capability::Params>,
+        peer: rmcp::Peer<rmcp::service::RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        tools::commission_capability::run(params, peer).await
+    }
 }
 
 #[tool_handler]

--- a/rust/crates/mcp/src/tools/commission_capability.rs
+++ b/rust/crates/mcp/src/tools/commission_capability.rs
@@ -1,0 +1,404 @@
+//! `commission_capability` — ask the studio registry to build a capability
+//! `search_catalog`/`list_catalog` couldn't find (commission-flow draft-00).
+//!
+//! Never auto-invoked: the first elicitation is consent to run the
+//! interview at all, a second (independent) safety net on top of
+//! `search_catalog`'s next-step text only *naming* this tool rather than
+//! calling it. v0 collects only the fields the studio's `NewRfq` wire shape
+//! already accepts (query/product/monetization/competition/budget_ceiling/
+//! buyer_npub); the richer cost-metrics interview (freshness, volume,
+//! upstream deps, WTP band) lands once the studio side adds a `brief`
+//! object to `schemas/rfq.json` — `NewRfq` is `deny_unknown_fields`, so
+//! sending those fields today would 422.
+
+use std::time::Duration;
+
+use pay_core::studios::{CommissionAmount, NewCommission, StudioRegistry, StudioSubmission};
+use rmcp::Peer;
+use rmcp::model::{
+    CallToolResult, Content, CreateElicitationRequestParam, ElicitationAction, ElicitationSchema,
+};
+use rmcp::schemars;
+use rmcp::service::RoleServer;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Outer deadline for a single elicitation round-trip, matching the
+/// existing auth-gate elicitation timeout (`mcp/src/auth.rs`).
+const ELICITATION_TIMEOUT: Duration = Duration::from_secs(300);
+/// How many times to check for a quote before telling the user to check
+/// back later. Kept short — an MCP tool call shouldn't hang for the
+/// arbitrary time a studio may take to review and quote an RFQ.
+const QUOTE_POLL_ATTEMPTS: u32 = 3;
+const QUOTE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct Params {
+    /// The capability the user wanted that no existing Pay provider covers.
+    #[schemars(
+        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. Only call this after a real catalog miss and only when the user wants to commission a new one; do not call speculatively."
+    )]
+    pub query: String,
+}
+
+pub async fn run(
+    params: Params,
+    peer: Peer<RoleServer>,
+) -> Result<CallToolResult, rmcp::ErrorData> {
+    let query = params.query.trim().to_string();
+    if query.is_empty() {
+        return Ok(super::tool_error(
+            "`query` must describe the missing capability",
+        ));
+    }
+
+    match ask_consent(&peer, &query).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "The user declined to commission this capability.".to_string(),
+            )]));
+        }
+        Err(message) => return Ok(super::tool_error(message)),
+    }
+
+    let brief = match ask_brief(&peer, &query).await {
+        Ok(brief) => brief,
+        Err(message) => return Ok(super::tool_error(message)),
+    };
+
+    let commission = NewCommission {
+        query: query.clone(),
+        product: brief.product,
+        monetization: brief.monetization,
+        competition: brief.competition,
+        budget_ceiling: brief.budget_ceiling,
+        buyer_npub: brief.buyer_npub,
+    };
+
+    let registry = match StudioRegistry::load() {
+        Ok(registry) => registry,
+        Err(e) => {
+            return Ok(super::tool_error(format!(
+                "Failed to load studio registry: {e}"
+            )));
+        }
+    };
+    if registry.studios.is_empty() {
+        return Ok(super::tool_error(
+            "No studios are registered in ~/.config/pay/studios.yaml.",
+        ));
+    }
+
+    let submissions = match pay_core::studios::submit_to_registry(
+        &registry,
+        &commission,
+        pay_core::ClientApp::Mcp,
+    )
+    .await
+    {
+        Ok(submissions) => submissions,
+        Err(e) => {
+            return Ok(super::tool_error(format!(
+                "Failed to submit commission: {e}"
+            )));
+        }
+    };
+
+    let results = poll_for_quotes(submissions).await;
+    let next_step = next_step_for(&results);
+
+    let response = serde_json::json!({
+        "query": query,
+        "submissions": results,
+        "next_step": next_step,
+    });
+
+    let json = match serde_json::to_string_pretty(&response) {
+        Ok(json) => json,
+        Err(e) => {
+            return Ok(super::tool_error(format!(
+                "Failed to serialize response: {e}"
+            )));
+        }
+    };
+
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+async fn ask_consent(peer: &Peer<RoleServer>, query: &str) -> Result<bool, String> {
+    let schema = ElicitationSchema::builder()
+        .required_bool("proceed")
+        .build()
+        .expect("required_bool registers `proceed` in properties");
+    let params = CreateElicitationRequestParam {
+        message: format!(
+            "Pay found no existing provider for \"{query}\". Start a commission interview to ask the studio registry for a custom-built endpoint? This submits a public demand record (RFQ) attributed to your identity; no payment is taken yet."
+        ),
+        requested_schema: schema,
+    };
+
+    let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
+        .await
+        .map_err(|_| "Timed out waiting for commission consent.".to_string())?
+        .map_err(|e| format!("Could not request commission consent: {e}"))?;
+
+    Ok(matches!(outcome.action, ElicitationAction::Accept)
+        && outcome
+            .content
+            .as_ref()
+            .and_then(|v| v.get("proceed"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false))
+}
+
+struct Brief {
+    product: Option<String>,
+    monetization: Option<String>,
+    competition: Vec<String>,
+    budget_ceiling: Option<CommissionAmount>,
+    buyer_npub: String,
+}
+
+async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String> {
+    let schema = ElicitationSchema::builder()
+        .required_string("buyer_npub")
+        .optional_string("product")
+        .optional_string("monetization")
+        .optional_string("competition")
+        .optional_number("budget_ceiling_amount", 0.0, 1_000_000_000.0)
+        .optional_string("budget_ceiling_mint")
+        .title("Commission brief")
+        .description(format!(
+            "Tell the studio what you need built for: \"{query}\""
+        ))
+        .build()
+        .map_err(|e| format!("failed to build brief schema: {e}"))?;
+
+    let params = CreateElicitationRequestParam {
+        message: "Describe what you want built. `buyer_npub` is your Nostr identity (e.g. your Buzz npub) — the studio attributes the demand record to it. Everything else is optional signal that helps the studio quote.".to_string(),
+        requested_schema: schema,
+    };
+
+    let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
+        .await
+        .map_err(|_| "Timed out waiting for the commission brief.".to_string())?
+        .map_err(|e| format!("Could not request the commission brief: {e}"))?;
+
+    match outcome.action {
+        ElicitationAction::Accept => {}
+        ElicitationAction::Decline => {
+            return Err("The user declined to provide a commission brief.".to_string());
+        }
+        ElicitationAction::Cancel => {
+            return Err("The user cancelled the commission brief.".to_string());
+        }
+    }
+
+    let content = outcome.content.unwrap_or_default();
+
+    let buyer_npub = str_field(&content, "buyer_npub").unwrap_or_default();
+    if buyer_npub.is_empty() {
+        return Err("`buyer_npub` is required to attribute the commission.".to_string());
+    }
+
+    let product = str_field(&content, "product");
+    let monetization = str_field(&content, "monetization");
+    let competition = str_field(&content, "competition")
+        .map(|raw| {
+            raw.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let budget_amount = content
+        .get("budget_ceiling_amount")
+        .and_then(|v| v.as_f64());
+    let budget_mint = str_field(&content, "budget_ceiling_mint");
+    let budget_ceiling = match (budget_amount, budget_mint) {
+        (Some(amount), Some(mint)) if amount > 0.0 => Some(CommissionAmount {
+            amount: amount.round() as u64,
+            mint,
+        }),
+        _ => None,
+    };
+
+    Ok(Brief {
+        product,
+        monetization,
+        competition,
+        budget_ceiling,
+        buyer_npub,
+    })
+}
+
+fn str_field(content: &serde_json::Value, key: &str) -> Option<String> {
+    content
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[derive(Debug, Serialize)]
+struct SubmissionResult {
+    studio: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rfq_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quote: Option<serde_json::Value>,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+async fn poll_for_quotes(submissions: Vec<StudioSubmission>) -> Vec<SubmissionResult> {
+    let mut results = Vec::with_capacity(submissions.len());
+    for submission in submissions {
+        results.push(poll_one(submission).await);
+    }
+    results
+}
+
+async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
+    let StudioSubmission {
+        studio,
+        rfq_url,
+        rfq,
+        error,
+    } = submission;
+
+    let Some(rfq) = rfq else {
+        return SubmissionResult {
+            studio,
+            rfq_id: None,
+            quote: None,
+            status: "failed",
+            error,
+        };
+    };
+
+    let Some(id) = rfq.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+        return SubmissionResult {
+            studio,
+            rfq_id: None,
+            quote: None,
+            status: "failed",
+            error: Some("studio response was missing the rfq id".to_string()),
+        };
+    };
+
+    for attempt in 0..QUOTE_POLL_ATTEMPTS {
+        match pay_core::studios::poll_quote(pay_core::ClientApp::Mcp, &rfq_url, &id).await {
+            Ok(Some(quote)) => {
+                return SubmissionResult {
+                    studio,
+                    rfq_id: Some(id),
+                    quote: Some(quote),
+                    status: "quoted",
+                    error: None,
+                };
+            }
+            Ok(None) => {
+                if attempt + 1 < QUOTE_POLL_ATTEMPTS {
+                    tokio::time::sleep(QUOTE_POLL_INTERVAL).await;
+                }
+            }
+            Err(e) => {
+                return SubmissionResult {
+                    studio,
+                    rfq_id: Some(id),
+                    quote: None,
+                    status: "failed",
+                    error: Some(e.to_string()),
+                };
+            }
+        }
+    }
+
+    SubmissionResult {
+        studio,
+        rfq_id: Some(id),
+        quote: None,
+        status: "pending",
+        error: None,
+    }
+}
+
+fn next_step_for(results: &[SubmissionResult]) -> &'static str {
+    if results.iter().all(|r| r.status == "failed") {
+        "Every studio was unreachable or rejected the submission; show the user the errors and ask before retrying."
+    } else if results.iter().any(|r| r.status == "quoted") {
+        "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically."
+    } else {
+        "No studio has quoted yet. Tell the user the commission was submitted and to check back later; do not resubmit the same query."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn params_reject_empty_query() {
+        let params: Params = serde_json::from_str(r#"{"query": ""}"#).unwrap();
+        assert!(params.query.trim().is_empty());
+    }
+
+    #[test]
+    fn next_step_all_failed() {
+        let results = vec![SubmissionResult {
+            studio: "scarce".to_string(),
+            rfq_id: None,
+            quote: None,
+            status: "failed",
+            error: Some("connection refused".to_string()),
+        }];
+        assert!(next_step_for(&results).contains("unreachable"));
+    }
+
+    #[test]
+    fn next_step_quoted_takes_priority() {
+        let results = vec![
+            SubmissionResult {
+                studio: "a".to_string(),
+                rfq_id: Some("1".to_string()),
+                quote: None,
+                status: "pending",
+                error: None,
+            },
+            SubmissionResult {
+                studio: "b".to_string(),
+                rfq_id: Some("2".to_string()),
+                quote: Some(serde_json::json!({"price": 1})),
+                status: "quoted",
+                error: None,
+            },
+        ];
+        assert!(next_step_for(&results).contains("quote"));
+    }
+
+    #[test]
+    fn next_step_pending_when_nothing_failed_or_quoted() {
+        let results = vec![SubmissionResult {
+            studio: "scarce".to_string(),
+            rfq_id: Some("1".to_string()),
+            quote: None,
+            status: "pending",
+            error: None,
+        }];
+        assert!(next_step_for(&results).contains("check back later"));
+    }
+
+    #[test]
+    fn str_field_trims_and_treats_blank_as_absent() {
+        let content = serde_json::json!({"a": "  hello  ", "b": "   ", "c": 3});
+        assert_eq!(str_field(&content, "a").as_deref(), Some("hello"));
+        assert_eq!(str_field(&content, "b"), None);
+        assert_eq!(str_field(&content, "c"), None);
+        assert_eq!(str_field(&content, "missing"), None);
+    }
+}

--- a/rust/crates/mcp/src/tools/create_skill.rs
+++ b/rust/crates/mcp/src/tools/create_skill.rs
@@ -105,9 +105,9 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
             if is_error {
                 Ok(super::tool_error(response))
             } else {
-                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-                    response,
-                )]))
+                Ok(CallToolResult::success(vec![
+                    rmcp::model::ContentBlock::text(response),
+                ]))
             }
         }
         Err(errors) => {

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -1,6 +1,8 @@
+#![allow(deprecated)] // MCP roots remain required for local-file authorization.
+
 use base64::{Engine, engine::general_purpose};
 use pay_core::client::fetch::{RedirectPolicy, RequestBody};
-use rmcp::model::{CallToolResult, Content, RawResource, Root};
+use rmcp::model::{CallToolResult, ContentBlock, Resource, Root};
 use rmcp::schemars;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -181,14 +183,14 @@ pub async fn run(
         RedirectPolicy::Follow
     };
 
-    let response = tokio::task::spawn_blocking(move || {
+    let response = crate::auth::spawn_blocking_with_elicitation(&peer, move |elicitation| {
         do_paid_fetch(
             &method,
             &url,
             &headers,
             body.as_ref(),
             redirect_policy,
-            Some(peer),
+            Some(elicitation),
         )
     })
     .await
@@ -438,22 +440,22 @@ fn body_to_mcp_content(
     body: Vec<u8>,
     content_type: Option<&str>,
     empty_message: &str,
-) -> Vec<Content> {
+) -> Vec<ContentBlock> {
     if body.is_empty() {
-        return vec![Content::text(empty_message.to_string())];
+        return vec![ContentBlock::text(empty_message.to_string())];
     }
 
     let mime = mime_from_content_type(content_type);
 
     if mime.starts_with("image/") {
         let encoded = general_purpose::STANDARD.encode(&body);
-        return vec![Content::image(encoded, mime)];
+        return vec![ContentBlock::image(encoded, mime)];
     }
 
     if is_binary_content_type(&mime) {
         return match write_body_to_tempfile(&body, &mime) {
             Ok(path) => {
-                let note = Content::text(format!(
+                let note = ContentBlock::text(format!(
                     "Binary response ({} bytes, {mime}) written to {path}",
                     body.len()
                 ));
@@ -468,7 +470,7 @@ fn body_to_mcp_content(
                     vec![note]
                 }
             }
-            Err(err) => vec![Content::text(format!(
+            Err(err) => vec![ContentBlock::text(format!(
                 "Binary response ({} bytes, {mime}) — failed to spill to tempfile: {err}",
                 body.len()
             ))],
@@ -559,7 +561,7 @@ struct ExtractedMedia {
 /// JSON with a `<mime, N bytes → /path>` placeholder. Images are additionally
 /// surfaced as `Content::image` so the model can see them. Whatever text
 /// remains is size-capped by [`text_content_capped`].
-fn text_body_to_content(text: String) -> Vec<Content> {
+fn text_body_to_content(text: String) -> Vec<ContentBlock> {
     if let Ok(mut value) = serde_json::from_str::<Value>(&text) {
         let mut extracted = Vec::new();
         extract_media_from_json(&mut value, &mut extracted);
@@ -585,9 +587,12 @@ fn text_body_to_content(text: String) -> Vec<Content> {
 ///   for handing a client a file by reference — clients that support these
 ///   types can open/play them, and we avoid inlining multi-megabyte base64
 ///   that would flood the context.
-fn media_as_content_block(media: &ExtractedMedia) -> Option<Content> {
+fn media_as_content_block(media: &ExtractedMedia) -> Option<ContentBlock> {
     if media.mime.starts_with("image/") {
-        return Some(Content::image(media.encoded.clone(), media.mime.clone()));
+        return Some(ContentBlock::image(
+            media.encoded.clone(),
+            media.mime.clone(),
+        ));
     }
     if media.mime.starts_with("audio/")
         || media.mime.starts_with("video/")
@@ -603,34 +608,34 @@ fn media_as_content_block(media: &ExtractedMedia) -> Option<Content> {
 }
 
 /// Build a `resource_link` content block referencing a media file on disk.
-fn resource_link_for_file(path: &str, mime: &str, bytes: usize) -> Content {
+fn resource_link_for_file(path: &str, mime: &str, bytes: usize) -> ContentBlock {
     let name = path
         .rsplit(['/', '\\'])
         .next()
         .filter(|s| !s.is_empty())
         .unwrap_or(path)
         .to_string();
-    let mut resource = RawResource::new(format!("file://{path}"), name);
-    resource.mime_type = Some(mime.to_string());
-    resource.size = u32::try_from(bytes).ok();
-    Content::resource_link(resource)
+    let resource = Resource::new(format!("file://{path}"), name)
+        .with_mime_type(mime)
+        .with_size(bytes as u64);
+    ContentBlock::resource_link(resource)
 }
 
 /// Return the text as inline `Content::text`, or — when it exceeds
 /// [`MAX_TEXT_INLINE_BYTES`] — spill the full body to a tempfile and return a
 /// short preview plus the path, so a huge response can't flood the context.
-fn text_content_capped(text: String) -> Content {
+fn text_content_capped(text: String) -> ContentBlock {
     if text.len() <= MAX_TEXT_INLINE_BYTES {
-        return Content::text(text);
+        return ContentBlock::text(text);
     }
     let preview: String = text.chars().take(TEXT_PREVIEW_BYTES).collect();
     match write_body_to_tempfile(text.as_bytes(), "text/plain") {
-        Ok(path) => Content::text(format!(
+        Ok(path) => ContentBlock::text(format!(
             "Large text response ({} bytes) written to {path}. First {} chars:\n{preview}",
             text.len(),
             preview.len()
         )),
-        Err(err) => Content::text(format!(
+        Err(err) => ContentBlock::text(format!(
             "Large text response ({} bytes) — failed to spill to tempfile: {err}. First {} chars:\n{preview}",
             text.len(),
             preview.len()
@@ -827,7 +832,7 @@ fn do_paid_fetch(
     extra_headers: &[(String, String)],
     body: Option<&RequestBody>,
     redirect_policy: RedirectPolicy,
-    peer: Option<rmcp::Peer<rmcp::service::RoleServer>>,
+    elicitation: Option<tokio::sync::mpsc::UnboundedSender<crate::auth::BrokerRequest>>,
 ) -> Result<PaidFetchResult, pay_core::Error> {
     use pay_core::client::runner::RunOutcome;
 
@@ -845,7 +850,7 @@ fn do_paid_fetch(
     };
 
     // Build a fresh elicitation-backed AuthGate per signing operation when
-    // we have a peer AND no local biometric is available. A local Touch ID /
+    // we have a request broker AND no local biometric is available. A local Touch ID /
     // Windows Hello / polkit prompt is faster and more familiar than a
     // round-trip through the MCP client UI, so we prefer it whenever the
     // platform offers it. `PAY_FORCE_ELICITATION=1` opts back into the
@@ -854,9 +859,10 @@ fn do_paid_fetch(
     //
     // When None (e.g. unit tests, or biometrics-available path), each
     // `_with_override` call gets `None` and falls back to the platform
-    // default gate. The peer is cheap to clone (it wraps an Arc).
+    // default gate. The broker keeps server-to-client requests associated
+    // with the originating tools/call under MCP 2026-07-28 (SEP-2260).
     let make_auth_override = || -> pay_core::signer::AuthOverride {
-        let peer = peer.as_ref()?;
+        let elicitation = elicitation.as_ref()?;
         let force = std::env::var("PAY_FORCE_ELICITATION")
             .ok()
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -864,7 +870,10 @@ fn do_paid_fetch(
         if !force && pay_keystore::Keystore::any_biometric_available() {
             return None;
         }
-        Some(Box::new(crate::ElicitationAuth::new(peer.clone())) as Box<dyn pay_keystore::AuthGate>)
+        Some(
+            Box::new(crate::ElicitationAuth::via_broker(elicitation.clone()))
+                as Box<dyn pay_keystore::AuthGate>,
+        )
     };
 
     let store = pay_core::accounts::FileAccountsStore::default_path();
@@ -1303,12 +1312,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("photo.png");
         std::fs::write(&path, b"image bytes").unwrap();
-        let root = Root {
-            uri: reqwest::Url::from_directory_path(dir.path())
+        let root = Root::new(
+            reqwest::Url::from_directory_path(dir.path())
                 .unwrap()
                 .to_string(),
-            name: Some("workspace".to_string()),
-        };
+        )
+        .with_name("workspace");
 
         let file = resolve_body_file_path("photo.png", &[root]).unwrap();
         assert_eq!(file.path, std::fs::canonicalize(path).unwrap());
@@ -1320,12 +1329,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("payload.json");
         std::fs::write(&path, br#"{"approved":true}"#).unwrap();
-        let root = Root {
-            uri: reqwest::Url::from_directory_path(dir.path())
+        let root = Root::new(
+            reqwest::Url::from_directory_path(dir.path())
                 .unwrap()
                 .to_string(),
-            name: Some("workspace".to_string()),
-        };
+        )
+        .with_name("workspace");
 
         let file = resolve_body_file_path("payload.json", &[root]).unwrap();
         std::fs::write(&path, b"changed").unwrap();
@@ -1346,12 +1355,12 @@ mod tests {
         std::fs::create_dir(&outside).unwrap();
         std::fs::write(root_path.join("payload"), b"approved").unwrap();
         std::fs::write(outside.join("payload"), b"outside!").unwrap();
-        let root = Root {
-            uri: reqwest::Url::from_directory_path(&root_path)
+        let root = Root::new(
+            reqwest::Url::from_directory_path(&root_path)
                 .unwrap()
                 .to_string(),
-            name: Some("workspace".to_string()),
-        };
+        )
+        .with_name("workspace");
 
         let file = resolve_body_file_path("payload", &[root]).unwrap();
         std::fs::rename(&root_path, &moved_root).unwrap();
@@ -1364,12 +1373,11 @@ mod tests {
     fn rejects_file_outside_declared_roots() {
         let allowed = tempfile::tempdir().unwrap();
         let outside = tempfile::NamedTempFile::new().unwrap();
-        let root = Root {
-            uri: reqwest::Url::from_directory_path(allowed.path())
+        let root = Root::new(
+            reqwest::Url::from_directory_path(allowed.path())
                 .unwrap()
                 .to_string(),
-            name: None,
-        };
+        );
 
         let error = resolve_body_file_path(outside.path().to_str().unwrap(), &[root]).unwrap_err();
         assert!(error.contains("outside the MCP client's declared filesystem roots"));
@@ -1380,18 +1388,16 @@ mod tests {
         let first = tempfile::tempdir().unwrap();
         let second = tempfile::tempdir().unwrap();
         let roots = [
-            Root {
-                uri: reqwest::Url::from_directory_path(first.path())
+            Root::new(
+                reqwest::Url::from_directory_path(first.path())
                     .unwrap()
                     .to_string(),
-                name: None,
-            },
-            Root {
-                uri: reqwest::Url::from_directory_path(second.path())
+            ),
+            Root::new(
+                reqwest::Url::from_directory_path(second.path())
                     .unwrap()
                     .to_string(),
-                name: None,
-            },
+            ),
         ];
 
         let error = resolve_body_file_path("photo.png", &roots).unwrap_err();
@@ -1881,7 +1887,7 @@ mod tests {
             .find_map(|c| c.as_resource_link())
             .expect("resource_link");
         assert_eq!(link.mime_type.as_deref(), Some("application/pdf"));
-        assert_eq!(link.size, Some(body.len() as u32));
+        assert_eq!(link.size, Some(body.len() as u64));
         let _ = std::fs::remove_file(path);
     }
 

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -142,6 +142,7 @@ fn is_http_token_byte(byte: u8) -> bool {
 pub async fn run(
     params: Params,
     peer: rmcp::Peer<rmcp::service::RoleServer>,
+    payment_sessions: pay_core::session_manager::SessionManager,
 ) -> Result<CallToolResult, rmcp::ErrorData> {
     if params.body.is_some() && params.body_file.is_some() {
         return Ok(super::tool_error(
@@ -191,6 +192,7 @@ pub async fn run(
             body.as_ref(),
             redirect_policy,
             Some(elicitation),
+            &payment_sessions,
         )
     })
     .await
@@ -826,6 +828,79 @@ fn sniff_media_mime(bytes: &[u8]) -> Option<&'static str> {
 /// octet streams — round-trip without UTF-8 mangling.
 type PaidFetchResult = (Vec<u8>, Option<String>);
 
+type SessionOpener =
+    fn(
+        &pay_core::mpp::Challenge,
+        &dyn pay_core::accounts::AccountsStore,
+        Option<&str>,
+        Option<&str>,
+        &str,
+        bool,
+        pay_core::signer::AuthOverride,
+    ) -> Result<pay_core::session_manager::PreparedOperatorSession, pay_core::Error>;
+
+#[allow(clippy::too_many_arguments)]
+fn chosen_payment_headers(
+    chosen: pay_core::client::mpp::ChosenPayment,
+    store: &dyn pay_core::accounts::AccountsStore,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    resource_url: &str,
+    extra_headers: &[(String, String)],
+    auth_override: pay_core::signer::AuthOverride,
+) -> Result<Vec<(String, String)>, pay_core::Error> {
+    use pay_core::client::mpp::ChosenPayment;
+
+    let mut headers = extra_headers.to_vec();
+    match chosen {
+        ChosenPayment::Mpp(challenge) => {
+            let (authorization, _ephemeral) =
+                pay_core::client::mpp::build_credential_with_override(
+                    challenge.as_ref(),
+                    store,
+                    network_override,
+                    account_override,
+                    Some(resource_url),
+                    auth_override,
+                )?;
+            headers.push(("Authorization".to_string(), authorization));
+        }
+        ChosenPayment::X402(challenge) => {
+            let built = pay_core::client::x402::build_payment_with_override(
+                challenge.as_ref(),
+                store,
+                network_override,
+                account_override,
+                Some(resource_url),
+                auth_override,
+            )?;
+            headers.extend(
+                built
+                    .headers
+                    .into_iter()
+                    .map(|(name, value)| (name.to_string(), value)),
+            );
+        }
+        ChosenPayment::X402Upto(challenge) => {
+            let built = pay_core::client::x402::build_upto_payment_with_override(
+                challenge.as_ref(),
+                store,
+                network_override,
+                account_override,
+                Some(resource_url),
+                auth_override,
+            )?;
+            headers.extend(
+                built
+                    .headers
+                    .into_iter()
+                    .map(|(name, value)| (name.to_string(), value)),
+            );
+        }
+    }
+    Ok(headers)
+}
+
 fn do_paid_fetch(
     method: &str,
     url: &str,
@@ -833,6 +908,30 @@ fn do_paid_fetch(
     body: Option<&RequestBody>,
     redirect_policy: RedirectPolicy,
     elicitation: Option<tokio::sync::mpsc::UnboundedSender<crate::auth::BrokerRequest>>,
+    payment_sessions: &pay_core::session_manager::SessionManager,
+) -> Result<PaidFetchResult, pay_core::Error> {
+    do_paid_fetch_with_session_opener(
+        method,
+        url,
+        extra_headers,
+        body,
+        redirect_policy,
+        elicitation,
+        payment_sessions,
+        pay_core::session_manager::prepare_operator_session_with_override,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn do_paid_fetch_with_session_opener(
+    method: &str,
+    url: &str,
+    extra_headers: &[(String, String)],
+    body: Option<&RequestBody>,
+    redirect_policy: RedirectPolicy,
+    elicitation: Option<tokio::sync::mpsc::UnboundedSender<crate::auth::BrokerRequest>>,
+    payment_sessions: &pay_core::session_manager::SessionManager,
+    session_opener: SessionOpener,
 ) -> Result<PaidFetchResult, pay_core::Error> {
     use pay_core::client::runner::RunOutcome;
 
@@ -879,28 +978,71 @@ fn do_paid_fetch(
     let store = pay_core::accounts::FileAccountsStore::default_path();
     let network_override = std::env::var("PAY_NETWORK_ENFORCED").ok();
     let account_override = std::env::var("PAY_ACTIVE_ACCOUNT").ok();
+    let session_slot = payment_sessions.slot(
+        url,
+        network_override.as_deref(),
+        account_override.as_deref(),
+    )?;
+    let mut session = session_slot.blocking_acquire();
 
-    // SIWMPP pre-attach: if a cached authenticate token covers this URL
-    // (URL-prefix match against a tracked Active subscription with a
-    // non-expired token), attach it BEFORE the first fetch. On hit the
-    // server validates the token and skips the 402 entirely — no Touch
-    // ID prompt, no extra round trip. On miss this is a no-op.
+    // Pre-attach a cached subscription token or reusable operator-session
+    // proof before challenge discovery. Explicit caller authorization wins;
+    // subscriptions win over sessions because both occupy Authorization.
     let cached_auth_header =
         pay_core::client::authenticate::cached_header_for_resource(&store, url);
-    let initial_headers: Vec<(String, String)> = match cached_auth_header.as_deref() {
-        Some(token)
-            if !extra_headers
-                .iter()
-                .any(|(k, _)| k.eq_ignore_ascii_case("authorization")) =>
-        {
-            let mut h = extra_headers.to_vec();
-            h.push(("Authorization".to_string(), token.to_string()));
-            h
+    let has_explicit_authorization = extra_headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+    let mut initial_headers = extra_headers.to_vec();
+    let mut used_cached_session = false;
+    if !has_explicit_authorization {
+        if let Some(token) = cached_auth_header {
+            initial_headers.push(("Authorization".to_string(), token));
+        } else if let Some(authorization) = session.authorization() {
+            initial_headers.push(("Authorization".to_string(), authorization.to_string()));
+            used_cached_session = true;
         }
-        _ => extra_headers.to_vec(),
-    };
+    }
 
-    let outcome = fetch_request(&initial_headers)?;
+    let mut outcome = fetch_request(&initial_headers)?;
+    if used_cached_session {
+        outcome = match outcome {
+            completed @ RunOutcome::Completed { .. } => return interpret_retry(completed),
+            RunOutcome::PaymentRejected {
+                retryable: true, ..
+            } => {
+                let retried = fetch_request(&initial_headers)?;
+                match retried {
+                    completed @ RunOutcome::Completed { .. } => return interpret_retry(completed),
+                    rejected @ RunOutcome::PaymentRejected {
+                        retryable: true, ..
+                    } => return interpret_retry(rejected),
+                    RunOutcome::PaymentRejected {
+                        retryable: false, ..
+                    } => {
+                        session.clear();
+                        fetch_request(extra_headers)?
+                    }
+                    challenge @ RunOutcome::SessionChallenge { .. } => {
+                        session.clear();
+                        challenge
+                    }
+                    other => other,
+                }
+            }
+            RunOutcome::PaymentRejected {
+                retryable: false, ..
+            } => {
+                session.clear();
+                fetch_request(extra_headers)?
+            }
+            challenge @ RunOutcome::SessionChallenge { .. } => {
+                session.clear();
+                challenge
+            }
+            other => other,
+        };
+    }
 
     match outcome {
         RunOutcome::MppChallenge {
@@ -910,7 +1052,6 @@ fn do_paid_fetch(
             x402_upto_accepts,
             ..
         } => {
-            use pay_core::client::mpp::ChosenPayment;
             let mut challenges = Vec::with_capacity(1 + alternatives.len());
             challenges.push((*challenge).clone());
             challenges.extend(alternatives);
@@ -925,54 +1066,15 @@ fn do_paid_fetch(
                 network_override.as_deref(),
                 account_override.as_deref(),
             )?;
-            let mut headers = extra_headers.to_vec();
-            match chosen {
-                ChosenPayment::Mpp(ch) => {
-                    let (auth_header, _ephemeral) =
-                        pay_core::client::mpp::build_credential_with_override(
-                            ch.as_ref(),
-                            &store,
-                            network_override.as_deref(),
-                            account_override.as_deref(),
-                            Some(url),
-                            make_auth_override(),
-                        )?;
-                    headers.push(("Authorization".to_string(), auth_header));
-                }
-                ChosenPayment::X402(challenge) => {
-                    let built_payment = pay_core::client::x402::build_payment_with_override(
-                        challenge.as_ref(),
-                        &store,
-                        network_override.as_deref(),
-                        account_override.as_deref(),
-                        Some(url),
-                        make_auth_override(),
-                    )?;
-                    headers.extend(
-                        built_payment
-                            .headers
-                            .into_iter()
-                            .map(|(name, value)| (name.to_string(), value)),
-                    );
-                }
-                ChosenPayment::X402Upto(challenge) => {
-                    let built_payment =
-                        pay_core::client::x402::build_upto_payment_with_override(
-                        challenge.as_ref(),
-                        &store,
-                        network_override.as_deref(),
-                        account_override.as_deref(),
-                        Some(url),
-                        make_auth_override(),
-                    )?;
-                    headers.extend(
-                        built_payment
-                            .headers
-                            .into_iter()
-                            .map(|(name, value)| (name.to_string(), value)),
-                    );
-                }
-            }
+            let headers = chosen_payment_headers(
+                chosen,
+                &store,
+                network_override.as_deref(),
+                account_override.as_deref(),
+                url,
+                extra_headers,
+                make_auth_override(),
+            )?;
             interpret_retry(fetch_request(&headers)?)
         }
         RunOutcome::X402Challenge { challenge, .. } => {
@@ -1073,9 +1175,54 @@ fn do_paid_fetch(
                 ))
             }
         }
-        RunOutcome::SessionChallenge { .. } => Err(pay_core::Error::Mpp(
-            "402 Payment Required (MPP session) — session payments require a stateful client with a Fiber channel".to_string(),
-        )),
+        RunOutcome::SessionChallenge {
+            challenge,
+            x402_alternative,
+            x402_upto_accepts,
+            ..
+        } => {
+            if !pay_core::session_manager::is_operator_session(&challenge)
+                && (x402_alternative.is_some() || !x402_upto_accepts.is_empty())
+            {
+                let chosen = pay_core::client::mpp::choose_payment(
+                    &[],
+                    x402_alternative.as_deref(),
+                    &x402_upto_accepts,
+                    &store,
+                    network_override.as_deref(),
+                    account_override.as_deref(),
+                )?;
+                let headers = chosen_payment_headers(
+                    chosen,
+                    &store,
+                    network_override.as_deref(),
+                    account_override.as_deref(),
+                    url,
+                    extra_headers,
+                    make_auth_override(),
+                )?;
+                return interpret_retry(fetch_request(&headers)?);
+            }
+
+            let prepared = session_opener(
+                &challenge,
+                &store,
+                network_override.as_deref(),
+                account_override.as_deref(),
+                url,
+                network_override.as_deref() == Some("localnet"),
+                make_auth_override(),
+            )?;
+            let mut headers = extra_headers.to_vec();
+            headers.push(("Authorization".to_string(), prepared.open_authorization));
+            let retry = fetch_request(&headers)?;
+            if matches!(retry, RunOutcome::Completed { .. }) {
+                session.adopt(prepared.use_authorization);
+            } else {
+                session.clear();
+            }
+            interpret_retry(retry)
+        }
         RunOutcome::SubscriptionChallenge {
             challenge,
             authenticate,
@@ -1124,9 +1271,7 @@ fn do_paid_fetch(
             "402 Payment Required but no recognized protocol".to_string(),
         )),
         RunOutcome::Completed {
-            body,
-            content_type,
-            ..
+            body, content_type, ..
         } => Ok((body.unwrap_or_default(), content_type)),
     }
 }
@@ -1219,6 +1364,62 @@ fn interpret_retry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static SESSION_OPEN_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn fake_session_opener(
+        _challenge: &pay_core::mpp::Challenge,
+        _store: &dyn pay_core::accounts::AccountsStore,
+        _network_override: Option<&str>,
+        _account_override: Option<&str>,
+        _resource_url: &str,
+        _sandbox: bool,
+        _auth_override: pay_core::signer::AuthOverride,
+    ) -> Result<pay_core::session_manager::PreparedOperatorSession, pay_core::Error> {
+        SESSION_OPEN_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(pay_core::session_manager::PreparedOperatorSession {
+            open_authorization: "Payment open-test".to_string(),
+            use_authorization: "Payment use-test".to_string(),
+        })
+    }
+
+    fn read_request(stream: &mut std::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let count = stream.read(&mut chunk).unwrap();
+            if count == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..count]);
+            if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    fn session_challenge_header() -> String {
+        let request = serde_json::json!({
+            "amount": "1",
+            "currency": "USDC",
+            "recipient": "So11111111111111111111111111111111111111112",
+            "methodDetails": {
+                "network": "solana:mainnet",
+                "channelProgram": "So11111111111111111111111111111111111111112",
+                "voucherSigner": "operator",
+                "operator": "So11111111111111111111111111111111111111112"
+            }
+        });
+        let encoded =
+            general_purpose::URL_SAFE_NO_PAD.encode(serde_json::to_vec(&request).unwrap());
+        format!(
+            "Payment id=\"session-test\", realm=\"test\", method=\"solana\", intent=\"session\", request=\"{encoded}\""
+        )
+    }
 
     #[test]
     fn params_deserialize_minimal() {
@@ -1487,8 +1688,104 @@ mod tests {
 
     #[test]
     fn do_paid_fetch_returns_error_for_invalid_url() {
-        let result = do_paid_fetch("GET", "not-a-url", &[], None, RedirectPolicy::Follow, None);
+        let result = do_paid_fetch(
+            "GET",
+            "not-a-url",
+            &[],
+            None,
+            RedirectPolicy::Follow,
+            None,
+            &pay_core::session_manager::SessionManager::default(),
+        );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn paid_fetch_opens_and_adopts_an_mpp_session() {
+        SESSION_OPEN_CALLS.store(0, Ordering::SeqCst);
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let challenge = session_challenge_header();
+        let x402 = serde_json::json!({
+            "x402Version": 2,
+            "accepts": [{
+                "scheme": "upto",
+                "network": "solana:mainnet",
+                "amount": "250000",
+                "asset": "USDC",
+                "payTo": "So11111111111111111111111111111111111111112"
+            }]
+        });
+        let x402 = general_purpose::STANDARD.encode(serde_json::to_vec(&x402).unwrap());
+
+        let server = std::thread::spawn(move || {
+            let (mut first, _) = listener.accept().unwrap();
+            let first_request = read_request(&mut first);
+            assert!(
+                !first_request
+                    .to_ascii_lowercase()
+                    .contains("authorization:")
+            );
+            let response = format!(
+                "HTTP/1.1 402 Payment Required\r\nWWW-Authenticate: {challenge}\r\nPayment-Required: {x402}\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+            );
+            first.write_all(response.as_bytes()).unwrap();
+
+            let (mut retry, _) = listener.accept().unwrap();
+            let retry_request = read_request(&mut retry);
+            assert!(
+                retry_request
+                    .to_ascii_lowercase()
+                    .contains("authorization: payment open-test")
+            );
+            retry
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                )
+                .unwrap();
+
+            let (mut reused, _) = listener.accept().unwrap();
+            let reused_request = read_request(&mut reused);
+            assert!(
+                reused_request
+                    .to_ascii_lowercase()
+                    .contains("authorization: payment use-test")
+            );
+            reused
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\nConnection: close\r\n\r\nreused",
+                )
+                .unwrap();
+        });
+
+        let manager = pay_core::session_manager::SessionManager::default();
+        let result = do_paid_fetch_with_session_opener(
+            "POST",
+            &format!("http://{address}/v1/chat"),
+            &[],
+            Some(&RequestBody::text("{}")),
+            RedirectPolicy::Follow,
+            None,
+            &manager,
+            fake_session_opener,
+        )
+        .unwrap();
+
+        assert_eq!(result.0, b"ok");
+        let reused = do_paid_fetch_with_session_opener(
+            "POST",
+            &format!("http://{address}/v1/chat"),
+            &[],
+            Some(&RequestBody::text("{}")),
+            RedirectPolicy::Follow,
+            None,
+            &manager,
+            fake_session_opener,
+        )
+        .unwrap();
+        assert_eq!(reused.0, b"reused");
+        assert_eq!(SESSION_OPEN_CALLS.load(Ordering::SeqCst), 1);
+        server.join().unwrap();
     }
 
     #[test]

--- a/rust/crates/mcp/src/tools/get_balance.rs
+++ b/rust/crates/mcp/src/tools/get_balance.rs
@@ -62,7 +62,7 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
         lines.push("No token balances found.".to_string());
     }
 
-    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-        lines.join("\n"),
-    )]))
+    Ok(CallToolResult::success(vec![
+        rmcp::model::ContentBlock::text(lines.join("\n")),
+    ]))
 }

--- a/rust/crates/mcp/src/tools/get_catalog_entry.rs
+++ b/rust/crates/mcp/src/tools/get_catalog_entry.rs
@@ -100,9 +100,9 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
         }
     };
 
-    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-        json,
-    )]))
+    Ok(CallToolResult::success(vec![
+        rmcp::model::ContentBlock::text(json),
+    ]))
 }
 
 fn endpoint_entry_for(base_url: &str, ep: &pay_core::skills::Endpoint) -> EndpointEntry {

--- a/rust/crates/mcp/src/tools/list_catalog.rs
+++ b/rust/crates/mcp/src/tools/list_catalog.rs
@@ -155,7 +155,7 @@ fn build_response(
         provider_count,
         categories: grouped.into_values().collect(),
         services: include_details.then_some(services),
-        next_step: "For an actionable task, call search_catalog with the user's real task. For a capability yes/no answer, answer from this full catalog.",
+        next_step: "For an actionable task, call search_catalog with the user's real task. For a capability yes/no answer, answer from this full catalog — but if the catalog does not cover the user's need, call search_catalog with the real task before answering no: on a miss it can offer to submit a capability request to the studio registry.",
     }
 }
 

--- a/rust/crates/mcp/src/tools/list_catalog.rs
+++ b/rust/crates/mcp/src/tools/list_catalog.rs
@@ -116,9 +116,9 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
         }
     };
 
-    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-        json,
-    )]))
+    Ok(CallToolResult::success(vec![
+        rmcp::model::ContentBlock::text(json),
+    ]))
 }
 
 fn build_response(

--- a/rust/crates/mcp/src/tools/list_catalog.rs
+++ b/rust/crates/mcp/src/tools/list_catalog.rs
@@ -155,7 +155,7 @@ fn build_response(
         provider_count,
         categories: grouped.into_values().collect(),
         services: include_details.then_some(services),
-        next_step: "For an actionable task, call search_catalog with the user's real task. For a capability yes/no answer, answer from this full catalog — but if the catalog does not cover the user's need, call search_catalog with the real task before answering no: on a miss it can offer to submit a capability request to the studio registry.",
+        next_step: "For an actionable task, call search_catalog with the user's real task. For a capability yes/no answer, answer from this full catalog — but if the catalog does not cover the user's need, call search_catalog with the real task before answering no: on a miss it prompts the user itself with an offer to have the capability built, published, and monetized under them (never pre-ask in chat; treat the gap as an opportunity, not a dead end).",
     }
 }
 

--- a/rust/crates/mcp/src/tools/mod.rs
+++ b/rust/crates/mcp/src/tools/mod.rs
@@ -1,9 +1,9 @@
-pub mod commission_capability;
 pub mod create_skill;
 pub mod curl;
 pub mod get_balance;
 pub mod get_catalog_entry;
 pub mod list_catalog;
+pub mod request_capability;
 pub mod search_catalog;
 pub mod topup;
 

--- a/rust/crates/mcp/src/tools/mod.rs
+++ b/rust/crates/mcp/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod commission_capability;
 pub mod create_skill;
 pub mod curl;
 pub mod get_balance;

--- a/rust/crates/mcp/src/tools/mod.rs
+++ b/rust/crates/mcp/src/tools/mod.rs
@@ -8,7 +8,7 @@ pub mod search_catalog;
 pub mod topup;
 
 pub(crate) fn tool_error(message: impl Into<String>) -> rmcp::model::CallToolResult {
-    rmcp::model::CallToolResult::error(vec![rmcp::model::Content::text(message.into())])
+    rmcp::model::CallToolResult::error(vec![rmcp::model::ContentBlock::text(message.into())])
 }
 
 #[cfg(test)]

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -1,4 +1,4 @@
-//! `commission_capability` — ask the studio registry to build a capability
+//! `request_capability` — ask the studio registry to build a capability
 //! `search_catalog`/`list_catalog` couldn't find (commission-flow draft-00).
 //!
 //! Never auto-invoked: the first elicitation is consent to run the
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use pay_core::studios::{CommissionAmount, NewCommission, StudioRegistry, StudioSubmission};
+use pay_core::studios::{BudgetAmount, NewCapabilityRequest, StudioRegistry, StudioSubmission};
 use rmcp::Peer;
 use rmcp::model::{
     CallToolResult, Content, CreateElicitationRequestParam, ElicitationAction, ElicitationSchema,
@@ -36,7 +36,7 @@ const QUOTE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 pub struct Params {
     /// The capability the user wanted that no existing Pay provider covers.
     #[schemars(
-        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. Only call this after a real catalog miss and only when the user wants to commission a new one; do not call speculatively."
+        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. Only call this after a real catalog miss and only when the user wants to request a new one; do not call speculatively."
     )]
     pub query: String,
 }
@@ -56,7 +56,7 @@ pub async fn run(
         Ok(true) => {}
         Ok(false) => {
             return Ok(CallToolResult::success(vec![Content::text(
-                "The user declined to commission this capability.".to_string(),
+                "The user declined to request this capability.".to_string(),
             )]));
         }
         Err(message) => return Ok(super::tool_error(message)),
@@ -67,7 +67,7 @@ pub async fn run(
         Err(message) => return Ok(super::tool_error(message)),
     };
 
-    let commission = NewCommission {
+    let request = NewCapabilityRequest {
         query: query.clone(),
         product: brief.product,
         monetization: brief.monetization,
@@ -90,20 +90,17 @@ pub async fn run(
         ));
     }
 
-    let submissions = match pay_core::studios::submit_to_registry(
-        &registry,
-        &commission,
-        pay_core::ClientApp::Mcp,
-    )
-    .await
-    {
-        Ok(submissions) => submissions,
-        Err(e) => {
-            return Ok(super::tool_error(format!(
-                "Failed to submit commission: {e}"
-            )));
-        }
-    };
+    let submissions =
+        match pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp)
+            .await
+        {
+            Ok(submissions) => submissions,
+            Err(e) => {
+                return Ok(super::tool_error(format!(
+                    "Failed to submit capability request: {e}"
+                )));
+            }
+        };
 
     let results = poll_for_quotes(submissions).await;
     let next_step = next_step_for(&results);
@@ -133,15 +130,15 @@ async fn ask_consent(peer: &Peer<RoleServer>, query: &str) -> Result<bool, Strin
         .expect("required_bool registers `proceed` in properties");
     let params = CreateElicitationRequestParam {
         message: format!(
-            "Pay found no existing provider for \"{query}\". Start a commission interview to ask the studio registry for a custom-built endpoint? This submits a public demand record (RFQ) attributed to your identity; no payment is taken yet."
+            "Pay found no existing provider for \"{query}\". Start a capability-request interview to ask the studio registry for a custom-built endpoint? This submits a public demand record (RFQ) attributed to your identity; no payment is taken yet."
         ),
         requested_schema: schema,
     };
 
     let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
         .await
-        .map_err(|_| "Timed out waiting for commission consent.".to_string())?
-        .map_err(|e| format!("Could not request commission consent: {e}"))?;
+        .map_err(|_| "Timed out waiting for capability-request consent.".to_string())?
+        .map_err(|e| format!("Could not obtain capability-request consent: {e}"))?;
 
     Ok(matches!(outcome.action, ElicitationAction::Accept)
         && outcome
@@ -156,7 +153,7 @@ struct Brief {
     product: Option<String>,
     monetization: Option<String>,
     competition: Vec<String>,
-    budget_ceiling: Option<CommissionAmount>,
+    budget_ceiling: Option<BudgetAmount>,
     buyer_npub: String,
 }
 
@@ -168,7 +165,7 @@ async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String
         .optional_string("competition")
         .optional_number("budget_ceiling_amount", 0.0, 1_000_000_000.0)
         .optional_string("budget_ceiling_mint")
-        .title("Commission brief")
+        .title("Capability brief")
         .description(format!(
             "Tell the studio what you need built for: \"{query}\""
         ))
@@ -182,16 +179,16 @@ async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String
 
     let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
         .await
-        .map_err(|_| "Timed out waiting for the commission brief.".to_string())?
-        .map_err(|e| format!("Could not request the commission brief: {e}"))?;
+        .map_err(|_| "Timed out waiting for the capability brief.".to_string())?
+        .map_err(|e| format!("Could not obtain the capability brief: {e}"))?;
 
     match outcome.action {
         ElicitationAction::Accept => {}
         ElicitationAction::Decline => {
-            return Err("The user declined to provide a commission brief.".to_string());
+            return Err("The user declined to provide a capability brief.".to_string());
         }
         ElicitationAction::Cancel => {
-            return Err("The user cancelled the commission brief.".to_string());
+            return Err("The user cancelled the capability brief.".to_string());
         }
     }
 
@@ -199,7 +196,7 @@ async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String
 
     let buyer_npub = str_field(&content, "buyer_npub").unwrap_or_default();
     if buyer_npub.is_empty() {
-        return Err("`buyer_npub` is required to attribute the commission.".to_string());
+        return Err("`buyer_npub` is required to attribute the capability request.".to_string());
     }
 
     let product = str_field(&content, "product");
@@ -218,7 +215,7 @@ async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String
         .and_then(|v| v.as_f64());
     let budget_mint = str_field(&content, "budget_ceiling_mint");
     let budget_ceiling = match (budget_amount, budget_mint) {
-        (Some(amount), Some(mint)) if amount > 0.0 => Some(CommissionAmount {
+        (Some(amount), Some(mint)) if amount > 0.0 => Some(BudgetAmount {
             amount: amount.round() as u64,
             mint,
         }),
@@ -334,7 +331,7 @@ fn next_step_for(results: &[SubmissionResult]) -> &'static str {
     } else if results.iter().any(|r| r.status == "quoted") {
         "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically."
     } else {
-        "No studio has quoted yet. Tell the user the commission was submitted and to check back later; do not resubmit the same query."
+        "No studio has quoted yet. Tell the user the capability request was submitted and to check back later; do not resubmit the same query."
     }
 }
 

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -1,194 +1,648 @@
-//! `request_capability` — ask the studio registry to build a capability
-//! `search_catalog`/`list_catalog` couldn't find (commission-flow draft-00).
+//! `request_capability` — refine a catalog miss locally, then submit a
+//! quote-ready RFQ to the configured studio registry.
 //!
-//! Never auto-invoked: a single elicitation is both the pitch and the
-//! consent gate — Accept submits, Decline/Cancel walks away with nothing
-//! sent. The prompt is two free-form questions (what to build, what they'd
-//! use today); after Accept the client's own model (MCP sampling, briefed
-//! by `request_capability_brief.md`) turns those answers into the
-//! structured brief — no typed form fields, no schema the user has to fit.
-//! The buyer is attributed by the Solana pubkey of the local Pay wallet
-//! (the key the engagement would be funded with), never prompted for.
+//! This is one resumable MCP tool call. MRTR keeps elicitation, local-model
+//! refinement, read-only catalog research, validation, and submission inside
+//! the original `tools/call`; no second tool call or hidden ACP session is
+//! required.
 
+#![allow(deprecated)] // Sampling is the standard MRTR inference input in MCP 2026-07-28.
+
+use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use pay_core::studios::{BudgetAmount, NewCapabilityRequest, StudioRegistry, StudioSubmission};
+use pay_core::studios::{
+    BudgetAmount, CapabilityBrief, NewCapabilityRequest, StudioRegistry, StudioSubmission,
+};
+use rand::RngCore;
 use rmcp::Peer;
 use rmcp::model::{
-    CallToolResult, Content, CreateElicitationRequestParam, CreateMessageRequestParam,
-    ElicitationAction, ElicitationSchema, LoggingLevel, LoggingMessageNotificationParam,
-    ProgressNotificationParam, ProgressToken, Role, SamplingMessage,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, CreateMessageRequest,
+    CreateMessageRequestParams, CreateMessageResult, ElicitRequest, ElicitRequestParams,
+    ElicitResult, ElicitationAction, ElicitationSchema, InputRequest, InputRequiredResult,
+    InputResponses, LoggingLevel, LoggingMessageNotificationParam, ProgressNotificationParam,
+    ProgressToken, RequestStateCodec, SamplingMessage, SamplingMessageContentBlock, SealOptions,
+    Tool, ToolAnnotations, ToolChoice,
 };
 use rmcp::schemars;
 use rmcp::service::RoleServer;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Outer deadline for a single elicitation round-trip, matching the
-/// existing auth-gate elicitation timeout (`mcp/src/auth.rs`).
-const ELICITATION_TIMEOUT: Duration = Duration::from_secs(300);
-/// How many times to check for a quote before telling the user to check
-/// back later. Kept short — an MCP tool call shouldn't hang for the
-/// arbitrary time a studio may take to review and quote an RFQ.
+const STATE_TTL: Duration = Duration::from_secs(10 * 60);
+const MAX_REFINEMENT_ROUNDS: u8 = 6;
+const SAMPLING_MAX_TOKENS: u32 = 1_600;
 const QUOTE_POLL_ATTEMPTS: u32 = 3;
 const QUOTE_POLL_INTERVAL: Duration = Duration::from_secs(2);
-/// Ceiling on the client-side sampling round-trip that structures the
-/// brief — local inference can be slow, but not unbounded; on timeout the
-/// raw answers ship instead.
-const SAMPLING_TIMEOUT: Duration = Duration::from_secs(60);
-const SAMPLING_MAX_TOKENS: u32 = 600;
-/// How often the in-flight status line rotates during a long stage.
 const STATUS_ROTATION_INTERVAL: Duration = Duration::from_secs(4);
-
-/// The elicitation pitch is a short YC-style hook, never a wall of text:
-/// hard cap 256 chars, with the quoted need truncated so any query fits.
 const PITCH_MAX_CHARS: usize = 256;
 const PITCH_NEED_MAX_CHARS: usize = 48;
-
-/// System prompt for the sampling call that structures the free-form
-/// answers (see module docs).
 const BRIEF_SKILL: &str = include_str!("request_capability_brief.md");
-
-/// The account whose pubkey attributes the request — same default network
-/// as `get_balance`.
 const WALLET_NETWORK: &str = "mainnet";
-/// Mainnet USDC — `budget_usd` is denominated in it (minor units = 1e-6).
 const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const USDC_PER_MINOR_UNIT: f64 = 1_000_000.0;
+const INTAKE_RESPONSE: &str = "capability_intake";
+const REFINEMENT_RESPONSE: &str = "capability_refinement";
+const RESEARCH_SEARCH_TOOL: &str = "search_pay_catalog";
+const RESEARCH_ENTRY_TOOL: &str = "inspect_pay_catalog_entry";
 
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct Params {
     /// The capability the user wanted that no existing Pay provider covers.
     #[schemars(
-        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. The tool asks the user before anything is sent, so calling it on a suspected miss is safe."
+        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. The tool itself asks for consent and completes refinement before anything reaches a studio."
     )]
     pub query: String,
 }
 
-/// Why a capability request didn't produce a submission. Split so callers
-/// with a graceful fallback (search_catalog's plain text hint) can treat a
-/// failed elicitation round-trip — commonly a client with no elicitation
-/// support — differently from a real error worth surfacing.
-pub(crate) enum CapabilityRequestError {
-    Elicitation(String),
-    Other(String),
+#[derive(Clone)]
+pub struct MrtrState {
+    codec: RequestStateCodec,
+    consumed: Arc<Mutex<HashSet<String>>>,
 }
 
-impl CapabilityRequestError {
-    pub(crate) fn into_message(self) -> String {
-        match self {
-            Self::Elicitation(message) | Self::Other(message) => message,
+impl Default for MrtrState {
+    fn default() -> Self {
+        let mut key = [0_u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut key);
+        Self {
+            codec: RequestStateCodec::new(key),
+            consumed: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
 
-pub(crate) enum CapabilityRequestOutcome {
-    Declined,
-    Submitted(serde_json::Value),
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FlowState {
+    id: String,
+    query: String,
+    buyer_solana_pubkey: String,
+    stage: Stage,
+    build: Option<String>,
+    today: Option<String>,
+    messages: Vec<SamplingMessage>,
+    refinement_round: u8,
 }
 
-pub async fn run(
-    params: Params,
-    peer: Peer<RoleServer>,
-    progress_token: Option<ProgressToken>,
-) -> Result<CallToolResult, rmcp::ErrorData> {
-    let query = params.query.trim().to_string();
-    if query.is_empty() {
-        return Ok(super::tool_error(
-            "`query` must describe the missing capability",
-        ));
-    }
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum Stage {
+    AwaitingIntake,
+    Refining,
+}
 
-    match run_capability_request(&peer, progress_token, &query).await {
-        Ok(CapabilityRequestOutcome::Declined) => Ok(CallToolResult::success(vec![Content::text(
-            "The user declined to request this capability.".to_string(),
-        )])),
-        Ok(CapabilityRequestOutcome::Submitted(response)) => {
-            let json = match serde_json::to_string_pretty(&response) {
-                Ok(json) => json,
-                Err(e) => {
-                    return Ok(super::tool_error(format!(
-                        "Failed to serialize response: {e}"
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct RefinedCapability {
+    product: String,
+    #[serde(default)]
+    monetization: Option<String>,
+    #[serde(default)]
+    competition: Vec<String>,
+    #[serde(default)]
+    budget_usd: Option<f64>,
+    brief: CapabilityBrief,
+    #[serde(default)]
+    sources: Vec<ResearchSource>,
+    #[serde(default)]
+    assumptions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ResearchSource {
+    label: String,
+    #[serde(default)]
+    url: Option<String>,
+    finding: String,
+}
+
+impl RefinedCapability {
+    fn validation_errors(&self) -> Vec<String> {
+        let mut errors = self.brief.validation_errors();
+        if self.product.trim().is_empty() {
+            errors.push("product must be non-empty".to_string());
+        }
+        for (index, value) in self.competition.iter().enumerate() {
+            if value.trim().is_empty() {
+                errors.push(format!("competition[{index}] must be non-empty"));
+            }
+        }
+        if self
+            .budget_usd
+            .is_some_and(|value| !value.is_finite() || value <= 0.0)
+        {
+            errors.push("budget_usd must be a positive finite number when present".to_string());
+        }
+        for (index, source) in self.sources.iter().enumerate() {
+            if source.label.trim().is_empty() {
+                errors.push(format!("sources[{index}].label must be non-empty"));
+            }
+            if source.finding.trim().is_empty() {
+                errors.push(format!("sources[{index}].finding must be non-empty"));
+            }
+        }
+        errors
+    }
+}
+
+/// Drive one MRTR round. The caller must pass the complete `tools/call`
+/// params because the generated rmcp router intentionally strips the echoed
+/// `requestState` and `inputResponses` before invoking a tool method.
+pub async fn run_mrtr(
+    request: CallToolRequestParams,
+    peer: Peer<RoleServer>,
+    state: &MrtrState,
+) -> Result<CallToolResponse, rmcp::ErrorData> {
+    let query = match parse_query(&request) {
+        Ok(query) => query,
+        Err(message) => return Ok(tool_error(message).into()),
+    };
+    if query.is_empty() {
+        return Ok(tool_error("`query` must describe the missing capability").into());
+    }
+    let buyer_solana_pubkey = match wallet_pubkey() {
+        Ok(pubkey) => pubkey,
+        Err(message) => return Ok(tool_error(message).into()),
+    };
+    run_mrtr_for_wallet(request, Some(peer), state, query, buyer_solana_pubkey).await
+}
+
+async fn run_mrtr_for_wallet(
+    request: CallToolRequestParams,
+    peer: Option<Peer<RoleServer>>,
+    state: &MrtrState,
+    query: String,
+    buyer_solana_pubkey: String,
+) -> Result<CallToolResponse, rmcp::ErrorData> {
+    let associated_data = associated_data(&request.name, &query, &buyer_solana_pubkey);
+    let progress_token = request
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.get_progress_token());
+
+    let Some(sealed) = request.request_state.as_deref() else {
+        if request.input_responses.is_some() {
+            return Ok(tool_error("MRTR inputResponses were provided without requestState").into());
+        }
+        let flow = FlowState {
+            id: random_id(),
+            query,
+            buyer_solana_pubkey,
+            stage: Stage::AwaitingIntake,
+            build: None,
+            today: None,
+            messages: Vec::new(),
+            refinement_round: 0,
+        };
+        return input_required(
+            state,
+            &associated_data,
+            &flow,
+            INTAKE_RESPONSE,
+            intake_request(&flow.query),
+        );
+    };
+
+    let mut flow: FlowState = match state
+        .codec
+        .open_json_with(sealed, associated_data.as_bytes())
+    {
+        Ok(flow) => flow,
+        Err(error) => {
+            return Ok(tool_error(format!(
+                "Capability refinement state is invalid or expired: {error}. Start the request again."
+            ))
+            .into());
+        }
+    };
+    if flow.query != query || flow.buyer_solana_pubkey != buyer_solana_pubkey {
+        return Ok(tool_error(
+            "Capability refinement state does not match this tool call or Pay wallet.",
+        )
+        .into());
+    }
+    let responses = match request.input_responses.as_ref() {
+        Some(responses) => responses,
+        None => return Ok(tool_error("MRTR retry is missing inputResponses").into()),
+    };
+
+    match flow.stage {
+        Stage::AwaitingIntake => {
+            let response: ElicitResult = match response_as(responses, INTAKE_RESPONSE) {
+                Ok(response) => response,
+                Err(message) => return Ok(tool_error(message).into()),
+            };
+            if !matches!(response.action, ElicitationAction::Accept) {
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
+                    "The user declined to request this capability.",
+                )])
+                .into());
+            }
+            let content = response.content.unwrap_or_default();
+            flow.build = str_field(&content, "build");
+            flow.today = str_field(&content, "today");
+            flow.stage = Stage::Refining;
+            flow.messages = vec![SamplingMessage::user_text(refinement_seed(&flow))];
+            input_required(
+                state,
+                &associated_data,
+                &flow,
+                REFINEMENT_RESPONSE,
+                sampling_request(&flow),
+            )
+        }
+        Stage::Refining => {
+            let response: CreateMessageResult = match response_as(responses, REFINEMENT_RESPONSE) {
+                Ok(response) => response,
+                Err(message) => return Ok(tool_error(message).into()),
+            };
+            if let Err(message) = response.validate() {
+                return Ok(
+                    tool_error(format!("Invalid local refinement response: {message}")).into(),
+                );
+            }
+            flow.messages.push(response.message.clone());
+
+            let tool_uses: Vec<_> = response
+                .message
+                .content
+                .iter()
+                .filter_map(SamplingMessageContentBlock::as_tool_use)
+                .cloned()
+                .collect();
+            if !tool_uses.is_empty() {
+                if flow.refinement_round >= MAX_REFINEMENT_ROUNDS {
+                    return Ok(round_limit_error().into());
+                }
+                let mut results = Vec::with_capacity(tool_uses.len());
+                for tool_use in tool_uses {
+                    let content = execute_research_tool(&tool_use.name, &tool_use.input).await;
+                    results.push(SamplingMessageContentBlock::tool_result(
+                        tool_use.id,
+                        vec![ContentBlock::text(content)],
+                    ));
+                }
+                flow.messages.push(SamplingMessage::new_multiple(
+                    rmcp::model::Role::User,
+                    results,
+                ));
+                flow.refinement_round += 1;
+                return input_required(
+                    state,
+                    &associated_data,
+                    &flow,
+                    REFINEMENT_RESPONSE,
+                    sampling_request(&flow),
+                );
+            }
+
+            let raw = response
+                .message
+                .content
+                .iter()
+                .filter_map(SamplingMessageContentBlock::as_text)
+                .map(|text| text.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let refined = parse_refined_capability(&raw);
+            let validation = match refined {
+                Ok(refined) => {
+                    let errors = refined.validation_errors();
+                    if errors.is_empty() {
+                        Ok(refined)
+                    } else {
+                        Err(errors)
+                    }
+                }
+                Err(message) => Err(vec![message]),
+            };
+            let refined = match validation {
+                Ok(refined) => refined,
+                Err(errors) => {
+                    if flow.refinement_round >= MAX_REFINEMENT_ROUNDS {
+                        return Ok(round_limit_error().into());
+                    }
+                    flow.messages.push(SamplingMessage::user_text(format!(
+                        "The candidate brief failed local validation. Correct every issue and return the complete JSON object again:\n- {}",
+                        errors.join("\n- ")
                     )));
+                    flow.refinement_round += 1;
+                    return input_required(
+                        state,
+                        &associated_data,
+                        &flow,
+                        REFINEMENT_RESPONSE,
+                        sampling_request(&flow),
+                    );
                 }
             };
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+
+            if !consume_once(state, &flow.id) {
+                return Ok(tool_error(
+                    "This capability refinement was already submitted or attempted; start a new request instead of replaying it.",
+                )
+                .into());
+            }
+            let Some(peer) = peer else {
+                return Ok(
+                    tool_error("MRTR test flow reached studio submission without a peer").into(),
+                );
+            };
+            submit_refined(flow, refined, peer, progress_token).await
         }
-        Err(error) => Ok(super::tool_error(error.into_message())),
     }
 }
 
-/// One elicitation (pitch + two optional free-form questions, Accept =
-/// consent), a sampling pass that structures the answers, then submit to
-/// every registered studio and poll for quotes. Shared by [`run`] (direct
-/// call) and `search_catalog`'s miss path. The wallet is resolved before
-/// prompting so a missing `pay setup` fails fast instead of interviewing
-/// the user and then erroring.
-pub(crate) async fn run_capability_request(
-    peer: &Peer<RoleServer>,
-    progress_token: Option<ProgressToken>,
-    query: &str,
-) -> Result<CapabilityRequestOutcome, CapabilityRequestError> {
-    let buyer_solana_pubkey = wallet_pubkey().map_err(CapabilityRequestError::Other)?;
+fn parse_query(request: &CallToolRequestParams) -> Result<String, String> {
+    let arguments = request.arguments.clone().unwrap_or_default();
+    if request.name == "request_capability" {
+        let params: Params = serde_json::from_value(serde_json::Value::Object(arguments))
+            .map_err(|error| format!("Invalid request_capability parameters: {error}"))?;
+        return Ok(params.query.trim().to_string());
+    }
+    arguments
+        .get("query")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| "`query` must describe the missing capability".to_string())
+}
 
-    let Some(brief) = ask_to_build(peer, query).await? else {
-        return Ok(CapabilityRequestOutcome::Declined);
-    };
-
-    let status = Status::new(peer.clone(), progress_token);
-
-    // Nothing typed means nothing to extract — the query itself is the
-    // whole brief, so skip the model round-trip.
-    let structured = if brief.build.is_none() && brief.today.is_none() {
-        StructuredBrief::default()
-    } else {
-        with_rotating_status(
-            &status,
-            &[
-                "Reading your brief…",
-                "Pulling out scope, comparables, and budget…",
-                "Writing the request studios will quote…",
-            ],
-            structure_brief(peer, query, &brief),
+fn input_required(
+    state: &MrtrState,
+    associated_data: &str,
+    flow: &FlowState,
+    key: &str,
+    request: InputRequest,
+) -> Result<CallToolResponse, rmcp::ErrorData> {
+    let sealed = state
+        .codec
+        .seal_json_with(
+            flow,
+            &SealOptions::new()
+                .associated_data(associated_data.as_bytes())
+                .ttl(STATE_TTL),
         )
-        .await
-    };
+        .map_err(|error| rmcp::ErrorData::internal_error(error.to_string(), None))?;
+    let mut requests = BTreeMap::new();
+    requests.insert(key.to_string(), request);
+    Ok(InputRequiredResult::new(Some(requests), Some(sealed)).into())
+}
 
-    let request = NewCapabilityRequest {
-        query: query.to_string(),
-        product: structured.product.or_else(|| brief.build.clone()),
-        monetization: structured.monetization,
-        competition: if structured.competition.is_empty() {
-            brief.today.clone().into_iter().collect()
-        } else {
-            structured.competition
+fn intake_request(query: &str) -> InputRequest {
+    let schema = ElicitationSchema::builder()
+        .optional_string_with("build", |field| {
+            field.title("What do we want to build?").description(
+                "Say it like you'd pitch a friend — “an API that forecasts Solana priority fees an hour ahead.” Any detail helps: inputs, outputs, budget.",
+            )
+        })
+        .optional_string_with("today", |field| {
+            field.title("What would you use today?").description(
+                "Even a clunky workaround — “I'd eyeball Jito's dashboard.” It shows the studios the bar to beat.",
+            )
+        })
+        .title("Build something people want")
+        .build()
+        .expect("static capability intake schema is valid");
+    InputRequest::Elicitation(ElicitRequest::new(
+        ElicitRequestParams::FormElicitationParams {
+            meta: None,
+            message: pitch(query),
+            requested_schema: schema,
         },
-        budget_ceiling: structured.budget_usd.and_then(budget_from_usd),
-        buyer_npub: None,
-        buyer_solana_pubkey: Some(buyer_solana_pubkey),
-    };
+    ))
+}
 
-    let registry = StudioRegistry::load().map_err(|e| {
-        CapabilityRequestError::Other(format!("Failed to load studio registry: {e}"))
-    })?;
+fn sampling_request(flow: &FlowState) -> InputRequest {
+    let params = CreateMessageRequestParams::new(flow.messages.clone(), SAMPLING_MAX_TOKENS)
+        .with_system_prompt(BRIEF_SKILL)
+        .with_tools(research_tools())
+        .with_tool_choice(ToolChoice::auto());
+    InputRequest::CreateMessage(CreateMessageRequest::new(params))
+}
+
+fn refinement_seed(flow: &FlowState) -> String {
+    let schema = serde_json::to_string_pretty(&schemars::schema_for!(RefinedCapability))
+        .expect("RefinedCapability schema serializes");
+    format!(
+        "Catalog search that missed:\n{}\n\nWhat the user wants to build:\n{}\n\nWhat they would use today:\n{}\n\nReturn one object matching this exact JSON Schema:\n{}",
+        flow.query,
+        flow.build
+            .as_deref()
+            .unwrap_or("(no answer — infer conservatively from the query)"),
+        flow.today
+            .as_deref()
+            .unwrap_or("(no answer — record unknowns as assumptions)"),
+        schema,
+    )
+}
+
+fn research_tools() -> Vec<Tool> {
+    let annotations = ToolAnnotations::new()
+        .read_only(true)
+        .destructive(false)
+        .idempotent(true)
+        .open_world(false);
+    vec![
+        Tool::new(
+            RESEARCH_SEARCH_TOOL,
+            "Search the local Pay catalog to confirm this capability is missing and identify adjacent services. This performs no paid API call.",
+            schema_object(serde_json::json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "query": { "type": "string", "minLength": 1 } },
+                "required": ["query"]
+            })),
+        )
+        .with_annotations(annotations.clone()),
+        Tool::new(
+            RESEARCH_ENTRY_TOOL,
+            "Inspect one local Pay catalog entry, including its declared endpoints and pricing. This performs no paid API call.",
+            schema_object(serde_json::json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "fqn": { "type": "string", "minLength": 1 } },
+                "required": ["fqn"]
+            })),
+        )
+        .with_annotations(annotations),
+    ]
+}
+
+fn schema_object(value: serde_json::Value) -> rmcp::model::JsonObject {
+    value
+        .as_object()
+        .expect("static schema is an object")
+        .clone()
+}
+
+async fn execute_research_tool(name: &str, input: &rmcp::model::JsonObject) -> String {
+    let catalog = match pay_core::skills::load_skills_for(pay_core::ClientApp::Mcp).await {
+        Ok(catalog) => catalog,
+        Err(error) => return format!("research tool failed to load the Pay catalog: {error}"),
+    };
+    match name {
+        RESEARCH_SEARCH_TOOL => {
+            let Some(query) = input.get("query").and_then(|value| value.as_str()) else {
+                return "research tool error: `query` must be a non-empty string".to_string();
+            };
+            let ranked = pay_core::skills::search_services_ranked(&catalog, query, None, 5);
+            capped_json(&serde_json::json!({ "query": query, "candidates": ranked }))
+        }
+        RESEARCH_ENTRY_TOOL => {
+            let Some(fqn) = input.get("fqn").and_then(|value| value.as_str()) else {
+                return "research tool error: `fqn` must be a non-empty string".to_string();
+            };
+            match catalog
+                .providers
+                .iter()
+                .find(|service| service.fqn.eq_ignore_ascii_case(fqn))
+            {
+                Some(service) => capped_json(service),
+                None => format!("No Pay catalog entry named `{fqn}` exists."),
+            }
+        }
+        other => format!(
+            "research tool `{other}` is not allowed; use {RESEARCH_SEARCH_TOOL} or {RESEARCH_ENTRY_TOOL}"
+        ),
+    }
+}
+
+fn capped_json(value: &impl Serialize) -> String {
+    const MAX_CHARS: usize = 12_000;
+    match serde_json::to_string_pretty(value) {
+        Ok(value) => truncate_chars(&value, MAX_CHARS),
+        Err(error) => format!("research result serialization failed: {error}"),
+    }
+}
+
+fn parse_refined_capability(raw: &str) -> Result<RefinedCapability, String> {
+    let value: serde_json::Value = serde_json::from_str(raw.trim())
+        .map_err(|error| format!("refinement output is not valid JSON: {error}"))?;
+    reject_tagged_variant_extras(&value, "freshness")?;
+    reject_tagged_variant_extras(&value, "state")?;
+    serde_json::from_value(value)
+        .map_err(|error| format!("refinement output does not match the required schema: {error}"))
+}
+
+/// Serde's internally tagged enums accept unknown variant fields even when a
+/// surrounding struct denies unknowns. Enforce the strict wire boundary
+/// explicitly for the two tagged Brief fields.
+fn reject_tagged_variant_extras(value: &serde_json::Value, field: &str) -> Result<(), String> {
+    let Some(object) = value
+        .get("brief")
+        .and_then(|brief| brief.get(field))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Ok(());
+    };
+    let kind = object.get("kind").and_then(serde_json::Value::as_str);
+    let allowed: &[&str] = match (field, kind) {
+        ("freshness", Some("realtime")) | ("state", Some("none" | "cache")) => &["kind"],
+        ("freshness", Some("cached")) => &["kind", "ttl_seconds"],
+        ("freshness", Some("scheduled")) => &["kind", "cron"],
+        ("state", Some("durable")) => &["kind", "gib"],
+        _ => return Ok(()), // serde reports a missing or unknown tag precisely.
+    };
+    let extras: Vec<_> = object
+        .keys()
+        .filter(|key| !allowed.contains(&key.as_str()))
+        .cloned()
+        .collect();
+    if extras.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "brief.{field} contains unknown field(s): {}",
+            extras.join(", ")
+        ))
+    }
+}
+
+fn response_as<T: for<'de> Deserialize<'de>>(
+    responses: &InputResponses,
+    key: &str,
+) -> Result<T, String> {
+    let value = responses
+        .get(key)
+        .ok_or_else(|| format!("MRTR retry is missing the `{key}` response"))?;
+    serde_json::from_value(value.clone())
+        .map_err(|error| format!("MRTR `{key}` response is invalid: {error}"))
+}
+
+fn associated_data(tool: &str, query: &str, pubkey: &str) -> String {
+    format!("tools/call:{tool}\0wallet:{pubkey}\0query:{query}")
+}
+
+fn random_id() -> String {
+    let mut bytes = [0_u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn consume_once(state: &MrtrState, id: &str) -> bool {
+    state
+        .consumed
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(id.to_string())
+}
+
+fn round_limit_error() -> CallToolResult {
+    tool_error(format!(
+        "Local capability refinement did not produce a valid brief within {MAX_REFINEMENT_ROUNDS} rounds. Nothing was sent to a studio."
+    ))
+}
+
+fn tool_error(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(message.into())])
+}
+
+async fn submit_refined(
+    flow: FlowState,
+    refined: RefinedCapability,
+    peer: Peer<RoleServer>,
+    progress_token: Option<ProgressToken>,
+) -> Result<CallToolResponse, rmcp::ErrorData> {
+    let request = NewCapabilityRequest {
+        query: flow.query.clone(),
+        product: Some(refined.product.clone()),
+        monetization: refined.monetization.clone(),
+        competition: refined.competition.clone(),
+        budget_ceiling: refined.budget_usd.and_then(budget_from_usd),
+        buyer_npub: None,
+        buyer_solana_pubkey: Some(flow.buyer_solana_pubkey),
+        brief: Some(refined.brief.clone()),
+    };
+    let registry = match StudioRegistry::load() {
+        Ok(registry) => registry,
+        Err(error) => {
+            return Ok(tool_error(format!("Failed to load studio registry: {error}")).into());
+        }
+    };
     if registry.studios.is_empty() {
-        return Err(CapabilityRequestError::Other(
-            "No studios are registered in ~/.config/pay/studios.yaml.".to_string(),
-        ));
+        return Ok(tool_error("No studios are registered in ~/.config/pay/studios.yaml.").into());
     }
 
-    let submissions = with_rotating_status(
+    let status = Status::new(peer, progress_token);
+    let submissions = match with_rotating_status(
         &status,
-        &["Pitching it to the studio network…"],
+        &["Sending the quote-ready brief to studios…"],
         pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp),
     )
     .await
-    .map_err(|e| {
-        CapabilityRequestError::Other(format!("Failed to submit capability request: {e}"))
-    })?;
-
+    {
+        Ok(submissions) => submissions,
+        Err(error) => {
+            return Ok(tool_error(format!("Failed to submit capability request: {error}")).into());
+        }
+    };
     let results = with_rotating_status(
         &status,
         &[
@@ -199,87 +653,37 @@ pub(crate) async fn run_capability_request(
     )
     .await;
     let next_step = next_step_for(&results);
-
-    Ok(CapabilityRequestOutcome::Submitted(serde_json::json!({
-        "query": query,
+    let response = serde_json::json!({
+        "query": flow.query,
+        "refinement": {
+            "product": refined.product,
+            "brief": refined.brief,
+            "sources": refined.sources,
+            "assumptions": refined.assumptions,
+        },
         "submissions": results,
         "next_step": next_step,
-    })))
+    });
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string_pretty(&response).map_err(|error| {
+            rmcp::ErrorData::internal_error(format!("failed to serialize response: {error}"), None)
+        })?,
+    )])
+    .into())
 }
 
-/// The Solana pubkey the request is attributed to — read-only account
-/// metadata, no keypair load and no signing prompt.
 fn wallet_pubkey() -> Result<String, String> {
     let accounts = pay_core::accounts::AccountsFile::load()
-        .map_err(|e| format!("Failed to load Pay accounts: {e}"))?;
+        .map_err(|error| format!("Failed to load Pay accounts: {error}"))?;
     let Some((_name, account)) = accounts.account_for_network(WALLET_NETWORK) else {
         return Err(format!(
-            "No Pay account is configured for {WALLET_NETWORK}; run `pay setup` first — the capability request is attributed to your wallet."
+            "No Pay account is configured for {WALLET_NETWORK}; run `pay setup` first."
         ));
     };
     account
         .pubkey
         .clone()
         .ok_or_else(|| "Pay account has no pubkey. Run `pay setup` again.".to_string())
-}
-
-struct BriefInput {
-    build: Option<String>,
-    today: Option<String>,
-}
-
-/// The single prompt: sell the gap, collect two free-form answers, and
-/// take Accept as consent to submit. Both answers are plain text on
-/// purpose — a model structures them afterwards, so the user never fights
-/// a form. Returns `Ok(None)` on Decline/Cancel.
-async fn ask_to_build(
-    peer: &Peer<RoleServer>,
-    query: &str,
-) -> Result<Option<BriefInput>, CapabilityRequestError> {
-    let schema = ElicitationSchema::builder()
-        .optional_string_with("build", |s| {
-            s.title("What do we want to build?").description(
-                "Say it like you'd pitch a friend — \"an API that forecasts Solana priority fees an hour ahead\". Any detail helps: inputs, outputs, budget.",
-            )
-        })
-        .optional_string_with("today", |s| {
-            s.title("What service or app would you use today to achieve that?").description(
-                "Even a clunky workaround — \"I'd eyeball Jito's dashboard\". It shows studios the bar to beat.",
-            )
-        })
-        .title("Build something people want")
-        .build()
-        .map_err(|e| {
-            CapabilityRequestError::Other(format!("failed to build capability-request schema: {e}"))
-        })?;
-
-    let params = CreateElicitationRequestParam {
-        message: pitch(query),
-        requested_schema: schema,
-    };
-
-    let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
-        .await
-        .map_err(|_| {
-            CapabilityRequestError::Elicitation(
-                "Timed out waiting for the capability-request prompt.".to_string(),
-            )
-        })?
-        .map_err(|e| {
-            CapabilityRequestError::Elicitation(format!(
-                "Could not prompt for a capability request: {e}"
-            ))
-        })?;
-
-    if !matches!(outcome.action, ElicitationAction::Accept) {
-        return Ok(None);
-    }
-
-    let content = outcome.content.unwrap_or_default();
-    Ok(Some(BriefInput {
-        build: str_field(&content, "build"),
-        today: str_field(&content, "today"),
-    }))
 }
 
 fn pitch(query: &str) -> String {
@@ -291,85 +695,31 @@ fn pitch(query: &str) -> String {
     pitch
 }
 
-/// Char-boundary-safe truncation with an ellipsis, counting chars (not
-/// bytes) to match the pitch's char budget.
-fn truncate_chars(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
+fn truncate_chars(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
     }
-    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
-    out.push('…');
-    out
+    let mut output: String = value.chars().take(max.saturating_sub(1)).collect();
+    output.push('…');
+    output
 }
 
-#[derive(Debug, Default, Deserialize)]
-#[serde(default)]
-struct StructuredBrief {
-    product: Option<String>,
-    competition: Vec<String>,
-    budget_usd: Option<f64>,
-    monetization: Option<String>,
+fn budget_from_usd(usd: f64) -> Option<BudgetAmount> {
+    (usd.is_finite() && usd > 0.0).then(|| BudgetAmount {
+        amount: (usd * USDC_PER_MINOR_UNIT).round() as u64,
+        mint: USDC_MINT.to_string(),
+    })
 }
 
-fn supports_sampling(peer: &Peer<RoleServer>) -> bool {
-    peer.peer_info()
-        .is_some_and(|info| info.capabilities.sampling.is_some())
+fn str_field(content: &serde_json::Value, key: &str) -> Option<String> {
+    content
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
-/// Structure the free-form answers with the client's own model (MCP
-/// sampling), briefed by [`BRIEF_SKILL`]. Best-effort: returns the empty
-/// brief when the client can't sample, times out, or replies with
-/// something that isn't the JSON the skill asked for — the raw answers
-/// still ship in that case.
-async fn structure_brief(
-    peer: &Peer<RoleServer>,
-    query: &str,
-    brief: &BriefInput,
-) -> StructuredBrief {
-    if !supports_sampling(peer) {
-        return StructuredBrief::default();
-    }
-    let prompt = format!(
-        "Catalog search that missed: {query}\n\nWhat do we want to build:\n{}\n\nWhat would they use today:\n{}",
-        brief.build.as_deref().unwrap_or("(no answer)"),
-        brief.today.as_deref().unwrap_or("(no answer)"),
-    );
-    let request = CreateMessageRequestParam {
-        messages: vec![SamplingMessage {
-            role: Role::User,
-            content: Content::text(prompt),
-        }],
-        model_preferences: None,
-        system_prompt: Some(BRIEF_SKILL.to_string()),
-        include_context: None,
-        temperature: None,
-        max_tokens: SAMPLING_MAX_TOKENS,
-        stop_sequences: None,
-        metadata: None,
-    };
-    let Ok(Ok(result)) = tokio::time::timeout(SAMPLING_TIMEOUT, peer.create_message(request)).await
-    else {
-        return StructuredBrief::default();
-    };
-    result
-        .message
-        .content
-        .as_text()
-        .and_then(|t| parse_structured_brief(&t.text))
-        .unwrap_or_default()
-}
-
-/// Tolerates fences or prose around the JSON object the skill asked for.
-fn parse_structured_brief(raw: &str) -> Option<StructuredBrief> {
-    let start = raw.find('{')?;
-    let end = raw.rfind('}')?;
-    serde_json::from_str(raw.get(start..=end)?).ok()
-}
-
-/// Best-effort in-flight status line: MCP progress notifications when the
-/// client sent a `progressToken` with the call, logging notifications
-/// otherwise. Clients may ignore either — nothing here can fail the
-/// request.
 struct Status {
     peer: Peer<RoleServer>,
     token: Option<ProgressToken>,
@@ -386,71 +736,52 @@ impl Status {
     }
 
     async fn send(&self, message: &str) {
-        // Progress must be monotonically increasing per the MCP spec.
         let step = self.step.fetch_add(1, Ordering::Relaxed) + 1;
         match &self.token {
             Some(token) => {
                 let _ = self
                     .peer
-                    .notify_progress(ProgressNotificationParam {
-                        progress_token: token.clone(),
-                        progress: step as f64,
-                        total: None,
-                        message: Some(message.to_string()),
-                    })
+                    .notify_progress(
+                        ProgressNotificationParam::new(token.clone(), step as f64)
+                            .with_message(message),
+                    )
                     .await;
             }
             None => {
                 let _ = self
                     .peer
-                    .notify_logging_message(LoggingMessageNotificationParam {
-                        level: LoggingLevel::Info,
-                        logger: Some("request_capability".to_string()),
-                        data: serde_json::Value::String(message.to_string()),
-                    })
+                    .notify_logging_message(
+                        LoggingMessageNotificationParam::new(
+                            LoggingLevel::Info,
+                            serde_json::Value::String(message.to_string()),
+                        )
+                        .with_logger("request_capability"),
+                    )
                     .await;
             }
         }
     }
 }
 
-/// Run `fut` while rotating through `messages` on a timer, so the user
-/// sees what's happening during a long stage instead of a frozen spinner.
 async fn with_rotating_status<T>(
     status: &Status,
     messages: &[&str],
-    fut: impl Future<Output = T>,
+    future: impl Future<Output = T>,
 ) -> T {
     status.send(messages[0]).await;
-    tokio::pin!(fut);
+    tokio::pin!(future);
     let mut interval = tokio::time::interval(STATUS_ROTATION_INTERVAL);
-    interval.tick().await; // the first tick completes immediately
-    let mut next = 1usize;
+    interval.tick().await;
+    let mut next = 1;
     loop {
         tokio::select! {
-            out = &mut fut => return out,
+            output = &mut future => return output,
             _ = interval.tick() => {
                 status.send(messages[next % messages.len()]).await;
                 next += 1;
             }
         }
     }
-}
-
-fn budget_from_usd(usd: f64) -> Option<BudgetAmount> {
-    (usd.is_finite() && usd > 0.0).then(|| BudgetAmount {
-        amount: (usd * USDC_PER_MINOR_UNIT).round() as u64,
-        mint: USDC_MINT.to_string(),
-    })
-}
-
-fn str_field(content: &serde_json::Value, key: &str) -> Option<String> {
-    content
-        .get(key)
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
 }
 
 #[derive(Debug, Serialize)]
@@ -480,7 +811,6 @@ async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
         rfq,
         error,
     } = submission;
-
     let Some(rfq) = rfq else {
         return SubmissionResult {
             studio,
@@ -490,8 +820,11 @@ async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
             error,
         };
     };
-
-    let Some(id) = rfq.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+    let Some(id) = rfq
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    else {
         return SubmissionResult {
             studio,
             rfq_id: None,
@@ -500,7 +833,6 @@ async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
             error: Some("studio response was missing the rfq id".to_string()),
         };
     };
-
     for attempt in 0..QUOTE_POLL_ATTEMPTS {
         match pay_core::studios::poll_quote(pay_core::ClientApp::Mcp, &rfq_url, &id).await {
             Ok(Some(quote)) => {
@@ -512,23 +844,21 @@ async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
                     error: None,
                 };
             }
-            Ok(None) => {
-                if attempt + 1 < QUOTE_POLL_ATTEMPTS {
-                    tokio::time::sleep(QUOTE_POLL_INTERVAL).await;
-                }
+            Ok(None) if attempt + 1 < QUOTE_POLL_ATTEMPTS => {
+                tokio::time::sleep(QUOTE_POLL_INTERVAL).await;
             }
-            Err(e) => {
+            Ok(None) => {}
+            Err(error) => {
                 return SubmissionResult {
                     studio,
                     rfq_id: Some(id),
                     quote: None,
                     status: "failed",
-                    error: Some(e.to_string()),
+                    error: Some(error.to_string()),
                 };
             }
         }
     }
-
     SubmissionResult {
         studio,
         rfq_id: Some(id),
@@ -539,12 +869,12 @@ async fn poll_one(submission: StudioSubmission) -> SubmissionResult {
 }
 
 fn next_step_for(results: &[SubmissionResult]) -> &'static str {
-    if results.iter().all(|r| r.status == "failed") {
+    if results.iter().all(|result| result.status == "failed") {
         "Every studio was unreachable or rejected the submission; show the user the errors and ask before retrying."
-    } else if results.iter().any(|r| r.status == "quoted") {
-        "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically."
+    } else if results.iter().any(|result| result.status == "quoted") {
+        "A studio returned a quote. Present price, timeline, and terms before accepting; do not fund automatically."
     } else {
-        "No studio has quoted yet. Tell the user the capability request was submitted and to check back later; do not resubmit the same query."
+        "No studio has quoted yet. Tell the user the quote-ready request was submitted and to check back later; do not resubmit it."
     }
 }
 
@@ -552,115 +882,179 @@ fn next_step_for(results: &[SubmissionResult]) -> &'static str {
 mod tests {
     use super::*;
 
-    #[test]
-    fn params_reject_empty_query() {
-        let params: Params = serde_json::from_str(r#"{"query": ""}"#).unwrap();
-        assert!(params.query.trim().is_empty());
+    fn request(query: &str) -> CallToolRequestParams {
+        CallToolRequestParams::new("request_capability")
+            .with_arguments(schema_object(serde_json::json!({ "query": query })))
     }
 
-    #[test]
-    fn next_step_all_failed() {
-        let results = vec![SubmissionResult {
-            studio: "scarce".to_string(),
-            rfq_id: None,
-            quote: None,
-            status: "failed",
-            error: Some("connection refused".to_string()),
-        }];
-        assert!(next_step_for(&results).contains("unreachable"));
+    #[tokio::test]
+    async fn mrtr_retries_same_call_from_intake_to_refinement() {
+        let state = MrtrState::default();
+        let query = "forecast neighborhood pizza demand";
+        let wallet = "wallet".to_string();
+
+        let first = run_mrtr_for_wallet(request(query), None, &state, query.into(), wallet.clone())
+            .await
+            .unwrap();
+        let CallToolResponse::InputRequired(first) = first else {
+            panic!("initial call should require intake");
+        };
+        assert!(
+            first
+                .input_requests
+                .as_ref()
+                .is_some_and(|requests| requests.contains_key(INTAKE_RESPONSE))
+        );
+
+        let mut responses = InputResponses::new();
+        responses.insert(
+            INTAKE_RESPONSE.into(),
+            serde_json::to_value(ElicitResult::new(ElicitationAction::Accept).with_content(
+                serde_json::json!({
+                    "build": "a hyperlocal pizza delivery API",
+                    "today": "Uber Eats"
+                }),
+            ))
+            .unwrap(),
+        );
+        let retry = request(query)
+            .with_request_state(first.request_state.unwrap())
+            .with_input_responses(responses);
+        let second = run_mrtr_for_wallet(retry, None, &state, query.into(), wallet)
+            .await
+            .unwrap();
+        let CallToolResponse::InputRequired(second) = second else {
+            panic!("accepted intake should require local refinement");
+        };
+        let request = second
+            .input_requests
+            .as_ref()
+            .and_then(|requests| requests.get(REFINEMENT_RESPONSE))
+            .expect("refinement request");
+        assert!(matches!(request, InputRequest::CreateMessage(_)));
+        assert!(second.request_state.is_some());
     }
 
-    #[test]
-    fn next_step_quoted_takes_priority() {
-        let results = vec![
-            SubmissionResult {
-                studio: "a".to_string(),
-                rfq_id: Some("1".to_string()),
-                quote: None,
-                status: "pending",
-                error: None,
-            },
-            SubmissionResult {
-                studio: "b".to_string(),
-                rfq_id: Some("2".to_string()),
-                quote: Some(serde_json::json!({"price": 1})),
-                status: "quoted",
-                error: None,
-            },
-        ];
-        assert!(next_step_for(&results).contains("quote"));
-    }
-
-    #[test]
-    fn next_step_pending_when_nothing_failed_or_quoted() {
-        let results = vec![SubmissionResult {
-            studio: "scarce".to_string(),
-            rfq_id: Some("1".to_string()),
-            quote: None,
-            status: "pending",
-            error: None,
-        }];
-        assert!(next_step_for(&results).contains("check back later"));
-    }
-
-    #[test]
-    fn str_field_trims_and_treats_blank_as_absent() {
-        let content = serde_json::json!({"a": "  hello  ", "b": "   ", "c": 3});
-        assert_eq!(str_field(&content, "a").as_deref(), Some("hello"));
-        assert_eq!(str_field(&content, "b"), None);
-        assert_eq!(str_field(&content, "c"), None);
-        assert_eq!(str_field(&content, "missing"), None);
-    }
-
-    #[test]
-    fn budget_from_usd_converts_to_usdc_minor_units() {
-        let budget = budget_from_usd(12.5).unwrap();
-        assert_eq!(budget.amount, 12_500_000);
-        assert_eq!(budget.mint, USDC_MINT);
-    }
-
-    #[test]
-    fn budget_from_usd_rejects_non_positive_and_non_finite() {
-        assert!(budget_from_usd(0.0).is_none());
-        assert!(budget_from_usd(-3.0).is_none());
-        assert!(budget_from_usd(f64::NAN).is_none());
-        assert!(budget_from_usd(f64::INFINITY).is_none());
+    #[tokio::test]
+    async fn mrtr_decline_completes_without_refinement() {
+        let state = MrtrState::default();
+        let query = "forecast neighborhood pizza demand";
+        let wallet = "wallet".to_string();
+        let first = run_mrtr_for_wallet(request(query), None, &state, query.into(), wallet.clone())
+            .await
+            .unwrap();
+        let CallToolResponse::InputRequired(first) = first else {
+            panic!("initial call should require intake");
+        };
+        let mut responses = InputResponses::new();
+        responses.insert(
+            INTAKE_RESPONSE.into(),
+            serde_json::to_value(ElicitResult::new(ElicitationAction::Decline)).unwrap(),
+        );
+        let retry = request(query)
+            .with_request_state(first.request_state.unwrap())
+            .with_input_responses(responses);
+        let result = run_mrtr_for_wallet(retry, None, &state, query.into(), wallet)
+            .await
+            .unwrap();
+        let CallToolResponse::Complete(result) = result else {
+            panic!("declined intake should complete");
+        };
+        assert_eq!(result.is_error, Some(false));
+        assert!(state.consumed.lock().unwrap().is_empty());
     }
 
     #[test]
     fn pitch_stays_short_and_multiline() {
-        let short = pitch("solana priority fee forecasts");
-        assert!(short.contains("solana priority fee forecasts"));
-        let long = pitch(&"x".repeat(500));
-        for message in [&short, &long] {
-            assert!(
-                message.chars().count() <= PITCH_MAX_CHARS,
-                "pitch is {} chars",
-                message.chars().count()
-            );
+        for message in [
+            pitch("solana priority fee forecasts"),
+            pitch(&"x".repeat(500)),
+        ] {
+            assert!(message.chars().count() <= PITCH_MAX_CHARS);
             assert_eq!(message.matches('\n').count(), 2);
         }
     }
 
     #[test]
-    fn truncate_chars_is_char_boundary_safe() {
-        assert_eq!(truncate_chars("héllo", 10), "héllo");
-        assert_eq!(truncate_chars("héllo wörld", 6), "héllo…");
-        assert_eq!(truncate_chars("日本語のテキスト", 4), "日本語…");
+    fn request_state_is_bound_and_single_use() {
+        let state = MrtrState::default();
+        let flow = FlowState {
+            id: "one".into(),
+            query: "q".into(),
+            buyer_solana_pubkey: "wallet".into(),
+            stage: Stage::AwaitingIntake,
+            build: None,
+            today: None,
+            messages: vec![],
+            refinement_round: 0,
+        };
+        let token = state
+            .codec
+            .seal_json_with(
+                &flow,
+                &SealOptions::new().associated_data(b"bound").ttl(STATE_TTL),
+            )
+            .unwrap();
+        assert!(
+            state
+                .codec
+                .open_json_with::<FlowState>(&token, b"bound")
+                .is_ok()
+        );
+        assert!(
+            state
+                .codec
+                .open_json_with::<FlowState>(&token, b"other")
+                .is_err()
+        );
+        assert!(consume_once(&state, "one"));
+        assert!(!consume_once(&state, "one"));
     }
 
     #[test]
-    fn parse_structured_brief_tolerates_fences_and_prose() {
-        let fenced = "Here you go:\n```json\n{\"product\": \"fee forecast API\", \"competition\": [\"Jito dashboard\"], \"budget_usd\": 50}\n```";
-        let brief = parse_structured_brief(fenced).unwrap();
-        assert_eq!(brief.product.as_deref(), Some("fee forecast API"));
-        assert_eq!(brief.competition, vec!["Jito dashboard"]);
-        assert_eq!(brief.budget_usd, Some(50.0));
-        assert_eq!(brief.monetization, None);
+    fn invalid_brief_collects_actionable_errors() {
+        let value = serde_json::json!({
+            "product": " ",
+            "brief": {
+                "example_exchange": { "request": {}, "response": {} },
+                "freshness": { "kind": "cached", "ttl_seconds": 0 },
+                "volume": { "calls_per_month": 0, "avg_request_bytes": 0, "avg_response_bytes": 1 },
+                "compute_class": "cpu",
+                "state": { "kind": "durable", "gib": 0 },
+                "interface": "request_response"
+            }
+        });
+        let refined: RefinedCapability = serde_json::from_value(value).unwrap();
+        let errors = refined.validation_errors();
+        assert!(errors.iter().any(|error| error.contains("product")));
+        assert!(errors.iter().any(|error| error.contains("ttl_seconds")));
+        assert!(errors.iter().any(|error| error.contains("calls_per_month")));
+        assert!(errors.iter().any(|error| error.contains("state.gib")));
+    }
 
-        // Partial objects deserialize with defaults; garbage does not.
-        assert!(parse_structured_brief("{}").is_some());
-        assert!(parse_structured_brief("no json here").is_none());
-        assert!(parse_structured_brief("{not json}").is_none());
+    #[test]
+    fn parser_rejects_unknown_fields() {
+        let raw = r#"{
+            "product":"x",
+            "brief": {
+                "example_exchange":{"request":{},"response":{}},
+                "freshness":{"kind":"realtime"},
+                "volume":{"calls_per_month":1,"avg_request_bytes":0,"avg_response_bytes":1},
+                "compute_class":"proxy",
+                "state":{"kind":"none"},
+                "interface":"request_response"
+            },
+            "surprise": true
+        }"#;
+        assert!(parse_refined_capability(raw).is_err());
+
+        let nested = raw
+            .replace(
+                "\"freshness\":{\"kind\":\"realtime\"}",
+                "\"freshness\":{\"kind\":\"realtime\",\"surprise\":true}",
+            )
+            .replace(",\n            \"surprise\": true", "");
+        assert!(parse_refined_capability(&nested).is_err());
+        assert!(parse_refined_capability(&format!("Here is the brief:\n{raw}")).is_err());
     }
 }

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -342,18 +342,17 @@ async fn run_mrtr_for_wallet(
                 }
             };
 
-            if !consume_once(state, &flow.id) {
-                return Ok(tool_error(
-                    "This capability refinement was already submitted or attempted; start a new request instead of replaying it.",
-                )
-                .into());
-            }
+            let registry =
+                match prepare_submission_registry(state, &flow.id, StudioRegistry::load()) {
+                    Ok(registry) => registry,
+                    Err(error) => return Ok(error.into()),
+                };
             let Some(peer) = peer else {
                 return Ok(
                     tool_error("MRTR test flow reached studio submission without a peer").into(),
                 );
             };
-            submit_refined(flow, refined, peer, progress_token).await
+            submit_refined(flow, refined, registry, peer, progress_token).await
         }
     }
 }
@@ -594,6 +593,26 @@ fn consume_once(state: &MrtrState, id: &str) -> bool {
         .insert(id.to_string())
 }
 
+fn prepare_submission_registry(
+    state: &MrtrState,
+    flow_id: &str,
+    registry: pay_core::Result<StudioRegistry>,
+) -> std::result::Result<StudioRegistry, CallToolResult> {
+    let registry =
+        registry.map_err(|error| tool_error(format!("Failed to load studio registry: {error}")))?;
+    if registry.studios.is_empty() {
+        return Err(tool_error(
+            "No studios are registered in ~/.config/pay/studios.yaml.",
+        ));
+    }
+    if !consume_once(state, flow_id) {
+        return Err(tool_error(
+            "This capability refinement was already submitted or attempted; start a new request instead of replaying it.",
+        ));
+    }
+    Ok(registry)
+}
+
 fn round_limit_error() -> CallToolResult {
     tool_error(format!(
         "Local capability refinement did not produce a valid brief within {MAX_REFINEMENT_ROUNDS} rounds. Nothing was sent to a studio."
@@ -607,6 +626,7 @@ fn tool_error(message: impl Into<String>) -> CallToolResult {
 async fn submit_refined(
     flow: FlowState,
     refined: RefinedCapability,
+    registry: StudioRegistry,
     peer: Peer<RoleServer>,
     progress_token: Option<ProgressToken>,
 ) -> Result<CallToolResponse, rmcp::ErrorData> {
@@ -620,16 +640,6 @@ async fn submit_refined(
         buyer_solana_pubkey: Some(flow.buyer_solana_pubkey),
         brief: Some(refined.brief.clone()),
     };
-    let registry = match StudioRegistry::load() {
-        Ok(registry) => registry,
-        Err(error) => {
-            return Ok(tool_error(format!("Failed to load studio registry: {error}")).into());
-        }
-    };
-    if registry.studios.is_empty() {
-        return Ok(tool_error("No studios are registered in ~/.config/pay/studios.yaml.").into());
-    }
-
     let status = Status::new(peer, progress_token);
     let submissions = match with_rotating_status(
         &status,
@@ -1009,6 +1019,27 @@ mod tests {
         );
         assert!(consume_once(&state, "one"));
         assert!(!consume_once(&state, "one"));
+    }
+
+    #[test]
+    fn registry_validation_precedes_submission_replay_consumption() {
+        let state = MrtrState::default();
+
+        let malformed = prepare_submission_registry(
+            &state,
+            "one",
+            Err(pay_core::Error::Config("malformed registry".to_string())),
+        );
+        assert!(malformed.is_err());
+        assert!(state.consumed.lock().unwrap().is_empty());
+
+        let empty =
+            prepare_submission_registry(&state, "one", Ok(StudioRegistry { studios: vec![] }));
+        assert!(empty.is_err());
+        assert!(state.consumed.lock().unwrap().is_empty());
+
+        assert!(prepare_submission_registry(&state, "one", Ok(StudioRegistry::default())).is_ok());
+        assert!(prepare_submission_registry(&state, "one", Ok(StudioRegistry::default())).is_err());
     }
 
     #[test]

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -1,15 +1,14 @@
 //! `request_capability` — ask the studio registry to build a capability
 //! `search_catalog`/`list_catalog` couldn't find (commission-flow draft-00).
 //!
-//! Never auto-invoked: the first elicitation is consent to run the
-//! interview at all, a second (independent) safety net on top of
-//! `search_catalog`'s next-step text only *naming* this tool rather than
-//! calling it. v0 collects only the fields the studio's `NewRfq` wire shape
-//! already accepts (query/product/monetization/competition/budget_ceiling/
-//! buyer_npub); the richer cost-metrics interview (freshness, volume,
-//! upstream deps, WTP band) lands once the studio side adds a `brief`
-//! object to `schemas/rfq.json` — `NewRfq` is `deny_unknown_fields`, so
-//! sending those fields today would 422.
+//! Never auto-invoked: a single elicitation is both the pitch and the
+//! consent gate — Accept submits, Decline/Cancel walks away with nothing
+//! sent. The buyer is attributed by the Solana pubkey of the local Pay
+//! wallet (the key the engagement would be funded with), never prompted
+//! for. v0 sends only the fields the studio's `NewRfq` wire shape accepts;
+//! the richer cost-metrics brief (freshness, volume, upstream deps) lands
+//! once the studio side's `brief` object ships — `NewRfq` is
+//! `deny_unknown_fields`, so sending those fields today would 422.
 
 use std::time::Duration;
 
@@ -32,13 +31,42 @@ const ELICITATION_TIMEOUT: Duration = Duration::from_secs(300);
 const QUOTE_POLL_ATTEMPTS: u32 = 3;
 const QUOTE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
+/// The account whose pubkey attributes the request — same default network
+/// as `get_balance`.
+const WALLET_NETWORK: &str = "mainnet";
+/// Mainnet USDC — `budget_usd` is denominated in it (minor units = 1e-6).
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const USDC_PER_MINOR_UNIT: f64 = 1_000_000.0;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Params {
     /// The capability the user wanted that no existing Pay provider covers.
     #[schemars(
-        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. Only call this after a real catalog miss and only when the user wants to request a new one; do not call speculatively."
+        description = "The task or capability the user wanted that search_catalog/list_catalog found no usable provider for. The tool asks the user before anything is sent, so calling it on a suspected miss is safe."
     )]
     pub query: String,
+}
+
+/// Why a capability request didn't produce a submission. Split so callers
+/// with a graceful fallback (search_catalog's plain text hint) can treat a
+/// failed elicitation round-trip — commonly a client with no elicitation
+/// support — differently from a real error worth surfacing.
+pub(crate) enum CapabilityRequestError {
+    Elicitation(String),
+    Other(String),
+}
+
+impl CapabilityRequestError {
+    pub(crate) fn into_message(self) -> String {
+        match self {
+            Self::Elicitation(message) | Self::Other(message) => message,
+        }
+    }
+}
+
+pub(crate) enum CapabilityRequestOutcome {
+    Declined,
+    Submitted(serde_json::Value),
 }
 
 pub async fn run(
@@ -52,18 +80,11 @@ pub async fn run(
         ));
     }
 
-    match ask_consent(&peer, &query).await {
-        Ok(true) => {}
-        Ok(false) => {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "The user declined to request this capability.".to_string(),
-            )]));
-        }
-        Err(message) => return Ok(super::tool_error(message)),
-    }
-
-    match run_capability_request(&peer, &query).await {
-        Ok(response) => {
+    match run_capability_request(&peer, &query, 0).await {
+        Ok(CapabilityRequestOutcome::Declined) => Ok(CallToolResult::success(vec![Content::text(
+            "The user declined to request this capability.".to_string(),
+        )])),
+        Ok(CapabilityRequestOutcome::Submitted(response)) => {
             let json = match serde_json::to_string_pretty(&response) {
                 Ok(json) => json,
                 Err(e) => {
@@ -74,155 +95,153 @@ pub async fn run(
             };
             Ok(CallToolResult::success(vec![Content::text(json)]))
         }
-        Err(message) => Ok(super::tool_error(message)),
+        Err(error) => Ok(super::tool_error(error.into_message())),
     }
 }
 
-/// Interview the user for a capability brief, submit it to every registered
-/// studio, and poll for quotes. Shared by [`run`] (direct call) and
-/// `search_catalog`'s miss-path elicitation — both callers must obtain
-/// [`ask_consent`] first; this function assumes consent is already granted.
+/// One elicitation (pitch + optional details/budget, Accept = consent),
+/// then submit to every registered studio and poll for quotes. Shared by
+/// [`run`] (direct call) and `search_catalog`'s miss path. The wallet is
+/// resolved before prompting so a missing `pay setup` fails fast instead
+/// of interviewing the user and then erroring.
 pub(crate) async fn run_capability_request(
     peer: &Peer<RoleServer>,
     query: &str,
-) -> Result<serde_json::Value, String> {
-    let brief = ask_brief(peer, query).await?;
+    weak_candidates: usize,
+) -> Result<CapabilityRequestOutcome, CapabilityRequestError> {
+    let buyer_solana_pubkey = wallet_pubkey().map_err(CapabilityRequestError::Other)?;
+
+    let Some(brief) = ask_to_build(peer, query, weak_candidates).await? else {
+        return Ok(CapabilityRequestOutcome::Declined);
+    };
 
     let request = NewCapabilityRequest {
         query: query.to_string(),
-        product: brief.product,
-        monetization: brief.monetization,
-        competition: brief.competition,
-        budget_ceiling: brief.budget_ceiling,
-        buyer_npub: brief.buyer_npub,
+        product: brief.details,
+        monetization: None,
+        competition: vec![],
+        budget_ceiling: brief.budget_usd.and_then(budget_from_usd),
+        buyer_npub: None,
+        buyer_solana_pubkey: Some(buyer_solana_pubkey),
     };
 
-    let registry =
-        StudioRegistry::load().map_err(|e| format!("Failed to load studio registry: {e}"))?;
+    let registry = StudioRegistry::load().map_err(|e| {
+        CapabilityRequestError::Other(format!("Failed to load studio registry: {e}"))
+    })?;
     if registry.studios.is_empty() {
-        return Err("No studios are registered in ~/.config/pay/studios.yaml.".to_string());
+        return Err(CapabilityRequestError::Other(
+            "No studios are registered in ~/.config/pay/studios.yaml.".to_string(),
+        ));
     }
 
     let submissions =
         pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp)
             .await
-            .map_err(|e| format!("Failed to submit capability request: {e}"))?;
+            .map_err(|e| {
+                CapabilityRequestError::Other(format!("Failed to submit capability request: {e}"))
+            })?;
 
     let results = poll_for_quotes(submissions).await;
     let next_step = next_step_for(&results);
 
-    Ok(serde_json::json!({
+    Ok(CapabilityRequestOutcome::Submitted(serde_json::json!({
         "query": query,
         "submissions": results,
         "next_step": next_step,
-    }))
+    })))
 }
 
-pub(crate) async fn ask_consent(peer: &Peer<RoleServer>, query: &str) -> Result<bool, String> {
+/// The Solana pubkey the request is attributed to — read-only account
+/// metadata, no keypair load and no signing prompt.
+fn wallet_pubkey() -> Result<String, String> {
+    let accounts = pay_core::accounts::AccountsFile::load()
+        .map_err(|e| format!("Failed to load Pay accounts: {e}"))?;
+    let Some((_name, account)) = accounts.account_for_network(WALLET_NETWORK) else {
+        return Err(format!(
+            "No Pay account is configured for {WALLET_NETWORK}; run `pay setup` first — the capability request is attributed to your wallet."
+        ));
+    };
+    account
+        .pubkey
+        .clone()
+        .ok_or_else(|| "Pay account has no pubkey. Run `pay setup` again.".to_string())
+}
+
+struct BriefInput {
+    details: Option<String>,
+    budget_usd: Option<f64>,
+}
+
+/// The single prompt: sell the gap, collect optional signal, and take
+/// Accept as consent to submit. Returns `Ok(None)` on Decline/Cancel.
+async fn ask_to_build(
+    peer: &Peer<RoleServer>,
+    query: &str,
+    weak_candidates: usize,
+) -> Result<Option<BriefInput>, CapabilityRequestError> {
     let schema = ElicitationSchema::builder()
-        .required_bool("proceed")
+        .optional_string_with("details", |s| {
+            s.title("What should it do?").description(
+                "Anything the builders should know — inputs, outputs, must-haves. Leave empty to send your search as the brief.",
+            )
+        })
+        .optional_number_with("budget_usd", |n| {
+            n.range(0.0, 1_000_000.0)
+                .title("Budget ceiling (USD)")
+                .description("Rough signal for quoting — not a commitment, nothing is charged.")
+        })
+        .title("Let's get it built")
         .build()
-        .expect("required_bool registers `proceed` in properties");
+        .map_err(|e| {
+            CapabilityRequestError::Other(format!("failed to build capability-request schema: {e}"))
+        })?;
+
     let params = CreateElicitationRequestParam {
-        message: format!(
-            "Pay found no existing provider for \"{query}\". Start a capability-request interview to ask the studio registry for a custom-built endpoint? This submits a public demand record (RFQ) attributed to your identity; no payment is taken yet."
-        ),
+        message: pitch(query, weak_candidates),
         requested_schema: schema,
     };
 
     let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
         .await
-        .map_err(|_| "Timed out waiting for capability-request consent.".to_string())?
-        .map_err(|e| format!("Could not obtain capability-request consent: {e}"))?;
+        .map_err(|_| {
+            CapabilityRequestError::Elicitation(
+                "Timed out waiting for the capability-request prompt.".to_string(),
+            )
+        })?
+        .map_err(|e| {
+            CapabilityRequestError::Elicitation(format!(
+                "Could not prompt for a capability request: {e}"
+            ))
+        })?;
 
-    Ok(matches!(outcome.action, ElicitationAction::Accept)
-        && outcome
-            .content
-            .as_ref()
-            .and_then(|v| v.get("proceed"))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false))
-}
-
-struct Brief {
-    product: Option<String>,
-    monetization: Option<String>,
-    competition: Vec<String>,
-    budget_ceiling: Option<BudgetAmount>,
-    buyer_npub: String,
-}
-
-async fn ask_brief(peer: &Peer<RoleServer>, query: &str) -> Result<Brief, String> {
-    let schema = ElicitationSchema::builder()
-        .required_string("buyer_npub")
-        .optional_string("product")
-        .optional_string("monetization")
-        .optional_string("competition")
-        .optional_number("budget_ceiling_amount", 0.0, 1_000_000_000.0)
-        .optional_string("budget_ceiling_mint")
-        .title("Capability brief")
-        .description(format!(
-            "Tell the studio what you need built for: \"{query}\""
-        ))
-        .build()
-        .map_err(|e| format!("failed to build brief schema: {e}"))?;
-
-    let params = CreateElicitationRequestParam {
-        message: "Describe what you want built. `buyer_npub` is your Nostr identity (e.g. your Buzz npub) — the studio attributes the demand record to it. Everything else is optional signal that helps the studio quote.".to_string(),
-        requested_schema: schema,
-    };
-
-    let outcome = tokio::time::timeout(ELICITATION_TIMEOUT, peer.create_elicitation(params))
-        .await
-        .map_err(|_| "Timed out waiting for the capability brief.".to_string())?
-        .map_err(|e| format!("Could not obtain the capability brief: {e}"))?;
-
-    match outcome.action {
-        ElicitationAction::Accept => {}
-        ElicitationAction::Decline => {
-            return Err("The user declined to provide a capability brief.".to_string());
-        }
-        ElicitationAction::Cancel => {
-            return Err("The user cancelled the capability brief.".to_string());
-        }
+    if !matches!(outcome.action, ElicitationAction::Accept) {
+        return Ok(None);
     }
 
     let content = outcome.content.unwrap_or_default();
+    Ok(Some(BriefInput {
+        details: str_field(&content, "details"),
+        budget_usd: content.get("budget_usd").and_then(|v| v.as_f64()),
+    }))
+}
 
-    let buyer_npub = str_field(&content, "buyer_npub").unwrap_or_default();
-    if buyer_npub.is_empty() {
-        return Err("`buyer_npub` is required to attribute the capability request.".to_string());
-    }
-
-    let product = str_field(&content, "product");
-    let monetization = str_field(&content, "monetization");
-    let competition = str_field(&content, "competition")
-        .map(|raw| {
-            raw.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let budget_amount = content
-        .get("budget_ceiling_amount")
-        .and_then(|v| v.as_f64());
-    let budget_mint = str_field(&content, "budget_ceiling_mint");
-    let budget_ceiling = match (budget_amount, budget_mint) {
-        (Some(amount), Some(mint)) if amount > 0.0 => Some(BudgetAmount {
-            amount: amount.round() as u64,
-            mint,
-        }),
-        _ => None,
+fn pitch(query: &str, weak_candidates: usize) -> String {
+    let gap = if weak_candidates == 0 {
+        format!("Nothing in Pay's catalog can do \"{query}\" yet — you've found a gap.")
+    } else {
+        format!(
+            "Nothing in Pay's catalog truly fits \"{query}\" (only {weak_candidates} loose keyword matches, listed in the results) — you've found a gap."
+        )
     };
+    format!(
+        "{gap} Want it to exist? Accept and the studio network is asked to build and deploy an API tailored to your exact need — one you can monetize once it's live. Both fields are optional. Asking is free: the request goes to studios under your Pay wallet, and nothing is charged unless you later accept a quote."
+    )
+}
 
-    Ok(Brief {
-        product,
-        monetization,
-        competition,
-        budget_ceiling,
-        buyer_npub,
+fn budget_from_usd(usd: f64) -> Option<BudgetAmount> {
+    (usd.is_finite() && usd > 0.0).then(|| BudgetAmount {
+        amount: (usd * USDC_PER_MINOR_UNIT).round() as u64,
+        mint: USDC_MINT.to_string(),
     })
 }
 
@@ -392,5 +411,33 @@ mod tests {
         assert_eq!(str_field(&content, "b"), None);
         assert_eq!(str_field(&content, "c"), None);
         assert_eq!(str_field(&content, "missing"), None);
+    }
+
+    #[test]
+    fn budget_from_usd_converts_to_usdc_minor_units() {
+        let budget = budget_from_usd(12.5).unwrap();
+        assert_eq!(budget.amount, 12_500_000);
+        assert_eq!(budget.mint, USDC_MINT);
+    }
+
+    #[test]
+    fn budget_from_usd_rejects_non_positive_and_non_finite() {
+        assert!(budget_from_usd(0.0).is_none());
+        assert!(budget_from_usd(-3.0).is_none());
+        assert!(budget_from_usd(f64::NAN).is_none());
+        assert!(budget_from_usd(f64::INFINITY).is_none());
+    }
+
+    #[test]
+    fn pitch_mentions_weak_matches_only_when_present() {
+        let clean = pitch("solana priority fee forecasts", 0);
+        assert!(clean.contains("can do"));
+        assert!(!clean.contains("loose keyword"));
+        let noisy = pitch("solana priority fee forecasts", 5);
+        assert!(noisy.contains("5 loose keyword matches"));
+        for message in [&clean, &noisy] {
+            assert!(message.contains("monetize"));
+            assert!(message.contains("nothing is charged"));
+        }
     }
 }

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -62,13 +62,34 @@ pub async fn run(
         Err(message) => return Ok(super::tool_error(message)),
     }
 
-    let brief = match ask_brief(&peer, &query).await {
-        Ok(brief) => brief,
-        Err(message) => return Ok(super::tool_error(message)),
-    };
+    match run_capability_request(&peer, &query).await {
+        Ok(response) => {
+            let json = match serde_json::to_string_pretty(&response) {
+                Ok(json) => json,
+                Err(e) => {
+                    return Ok(super::tool_error(format!(
+                        "Failed to serialize response: {e}"
+                    )));
+                }
+            };
+            Ok(CallToolResult::success(vec![Content::text(json)]))
+        }
+        Err(message) => Ok(super::tool_error(message)),
+    }
+}
+
+/// Interview the user for a capability brief, submit it to every registered
+/// studio, and poll for quotes. Shared by [`run`] (direct call) and
+/// `search_catalog`'s miss-path elicitation — both callers must obtain
+/// [`ask_consent`] first; this function assumes consent is already granted.
+pub(crate) async fn run_capability_request(
+    peer: &Peer<RoleServer>,
+    query: &str,
+) -> Result<serde_json::Value, String> {
+    let brief = ask_brief(peer, query).await?;
 
     let request = NewCapabilityRequest {
-        query: query.clone(),
+        query: query.to_string(),
         product: brief.product,
         monetization: brief.monetization,
         competition: brief.competition,
@@ -76,54 +97,28 @@ pub async fn run(
         buyer_npub: brief.buyer_npub,
     };
 
-    let registry = match StudioRegistry::load() {
-        Ok(registry) => registry,
-        Err(e) => {
-            return Ok(super::tool_error(format!(
-                "Failed to load studio registry: {e}"
-            )));
-        }
-    };
+    let registry =
+        StudioRegistry::load().map_err(|e| format!("Failed to load studio registry: {e}"))?;
     if registry.studios.is_empty() {
-        return Ok(super::tool_error(
-            "No studios are registered in ~/.config/pay/studios.yaml.",
-        ));
+        return Err("No studios are registered in ~/.config/pay/studios.yaml.".to_string());
     }
 
     let submissions =
-        match pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp)
+        pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp)
             .await
-        {
-            Ok(submissions) => submissions,
-            Err(e) => {
-                return Ok(super::tool_error(format!(
-                    "Failed to submit capability request: {e}"
-                )));
-            }
-        };
+            .map_err(|e| format!("Failed to submit capability request: {e}"))?;
 
     let results = poll_for_quotes(submissions).await;
     let next_step = next_step_for(&results);
 
-    let response = serde_json::json!({
+    Ok(serde_json::json!({
         "query": query,
         "submissions": results,
         "next_step": next_step,
-    });
-
-    let json = match serde_json::to_string_pretty(&response) {
-        Ok(json) => json,
-        Err(e) => {
-            return Ok(super::tool_error(format!(
-                "Failed to serialize response: {e}"
-            )));
-        }
-    };
-
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    }))
 }
 
-async fn ask_consent(peer: &Peer<RoleServer>, query: &str) -> Result<bool, String> {
+pub(crate) async fn ask_consent(peer: &Peer<RoleServer>, query: &str) -> Result<bool, String> {
     let schema = ElicitationSchema::builder()
         .required_bool("proceed")
         .build()

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -3,19 +3,23 @@
 //!
 //! Never auto-invoked: a single elicitation is both the pitch and the
 //! consent gate — Accept submits, Decline/Cancel walks away with nothing
-//! sent. The buyer is attributed by the Solana pubkey of the local Pay
-//! wallet (the key the engagement would be funded with), never prompted
-//! for. v0 sends only the fields the studio's `NewRfq` wire shape accepts;
-//! the richer cost-metrics brief (freshness, volume, upstream deps) lands
-//! once the studio side's `brief` object ships — `NewRfq` is
-//! `deny_unknown_fields`, so sending those fields today would 422.
+//! sent. The prompt is two free-form questions (what to build, what they'd
+//! use today); after Accept the client's own model (MCP sampling, briefed
+//! by `request_capability_brief.md`) turns those answers into the
+//! structured brief — no typed form fields, no schema the user has to fit.
+//! The buyer is attributed by the Solana pubkey of the local Pay wallet
+//! (the key the engagement would be funded with), never prompted for.
 
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use pay_core::studios::{BudgetAmount, NewCapabilityRequest, StudioRegistry, StudioSubmission};
 use rmcp::Peer;
 use rmcp::model::{
-    CallToolResult, Content, CreateElicitationRequestParam, ElicitationAction, ElicitationSchema,
+    CallToolResult, Content, CreateElicitationRequestParam, CreateMessageRequestParam,
+    ElicitationAction, ElicitationSchema, LoggingLevel, LoggingMessageNotificationParam,
+    ProgressNotificationParam, ProgressToken, Role, SamplingMessage,
 };
 use rmcp::schemars;
 use rmcp::service::RoleServer;
@@ -30,6 +34,22 @@ const ELICITATION_TIMEOUT: Duration = Duration::from_secs(300);
 /// arbitrary time a studio may take to review and quote an RFQ.
 const QUOTE_POLL_ATTEMPTS: u32 = 3;
 const QUOTE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Ceiling on the client-side sampling round-trip that structures the
+/// brief — local inference can be slow, but not unbounded; on timeout the
+/// raw answers ship instead.
+const SAMPLING_TIMEOUT: Duration = Duration::from_secs(60);
+const SAMPLING_MAX_TOKENS: u32 = 600;
+/// How often the in-flight status line rotates during a long stage.
+const STATUS_ROTATION_INTERVAL: Duration = Duration::from_secs(4);
+
+/// The elicitation pitch is a short YC-style hook, never a wall of text:
+/// hard cap 256 chars, with the quoted need truncated so any query fits.
+const PITCH_MAX_CHARS: usize = 256;
+const PITCH_NEED_MAX_CHARS: usize = 48;
+
+/// System prompt for the sampling call that structures the free-form
+/// answers (see module docs).
+const BRIEF_SKILL: &str = include_str!("request_capability_brief.md");
 
 /// The account whose pubkey attributes the request — same default network
 /// as `get_balance`.
@@ -72,6 +92,7 @@ pub(crate) enum CapabilityRequestOutcome {
 pub async fn run(
     params: Params,
     peer: Peer<RoleServer>,
+    progress_token: Option<ProgressToken>,
 ) -> Result<CallToolResult, rmcp::ErrorData> {
     let query = params.query.trim().to_string();
     if query.is_empty() {
@@ -80,7 +101,7 @@ pub async fn run(
         ));
     }
 
-    match run_capability_request(&peer, &query, 0).await {
+    match run_capability_request(&peer, progress_token, &query).await {
         Ok(CapabilityRequestOutcome::Declined) => Ok(CallToolResult::success(vec![Content::text(
             "The user declined to request this capability.".to_string(),
         )])),
@@ -99,28 +120,52 @@ pub async fn run(
     }
 }
 
-/// One elicitation (pitch + optional details/budget, Accept = consent),
-/// then submit to every registered studio and poll for quotes. Shared by
-/// [`run`] (direct call) and `search_catalog`'s miss path. The wallet is
-/// resolved before prompting so a missing `pay setup` fails fast instead
-/// of interviewing the user and then erroring.
+/// One elicitation (pitch + two optional free-form questions, Accept =
+/// consent), a sampling pass that structures the answers, then submit to
+/// every registered studio and poll for quotes. Shared by [`run`] (direct
+/// call) and `search_catalog`'s miss path. The wallet is resolved before
+/// prompting so a missing `pay setup` fails fast instead of interviewing
+/// the user and then erroring.
 pub(crate) async fn run_capability_request(
     peer: &Peer<RoleServer>,
+    progress_token: Option<ProgressToken>,
     query: &str,
-    weak_candidates: usize,
 ) -> Result<CapabilityRequestOutcome, CapabilityRequestError> {
     let buyer_solana_pubkey = wallet_pubkey().map_err(CapabilityRequestError::Other)?;
 
-    let Some(brief) = ask_to_build(peer, query, weak_candidates).await? else {
+    let Some(brief) = ask_to_build(peer, query).await? else {
         return Ok(CapabilityRequestOutcome::Declined);
+    };
+
+    let status = Status::new(peer.clone(), progress_token);
+
+    // Nothing typed means nothing to extract — the query itself is the
+    // whole brief, so skip the model round-trip.
+    let structured = if brief.build.is_none() && brief.today.is_none() {
+        StructuredBrief::default()
+    } else {
+        with_rotating_status(
+            &status,
+            &[
+                "Reading your brief…",
+                "Pulling out scope, comparables, and budget…",
+                "Writing the request studios will quote…",
+            ],
+            structure_brief(peer, query, &brief),
+        )
+        .await
     };
 
     let request = NewCapabilityRequest {
         query: query.to_string(),
-        product: brief.details,
-        monetization: None,
-        competition: vec![],
-        budget_ceiling: brief.budget_usd.and_then(budget_from_usd),
+        product: structured.product.or_else(|| brief.build.clone()),
+        monetization: structured.monetization,
+        competition: if structured.competition.is_empty() {
+            brief.today.clone().into_iter().collect()
+        } else {
+            structured.competition
+        },
+        budget_ceiling: structured.budget_usd.and_then(budget_from_usd),
         buyer_npub: None,
         buyer_solana_pubkey: Some(buyer_solana_pubkey),
     };
@@ -134,14 +179,25 @@ pub(crate) async fn run_capability_request(
         ));
     }
 
-    let submissions =
-        pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp)
-            .await
-            .map_err(|e| {
-                CapabilityRequestError::Other(format!("Failed to submit capability request: {e}"))
-            })?;
+    let submissions = with_rotating_status(
+        &status,
+        &["Pitching it to the studio network…"],
+        pay_core::studios::submit_to_registry(&registry, &request, pay_core::ClientApp::Mcp),
+    )
+    .await
+    .map_err(|e| {
+        CapabilityRequestError::Other(format!("Failed to submit capability request: {e}"))
+    })?;
 
-    let results = poll_for_quotes(submissions).await;
+    let results = with_rotating_status(
+        &status,
+        &[
+            "Waiting for studios to respond…",
+            "Checking for early quotes…",
+        ],
+        poll_for_quotes(submissions),
+    )
+    .await;
     let next_step = next_step_for(&results);
 
     Ok(CapabilityRequestOutcome::Submitted(serde_json::json!({
@@ -168,36 +224,37 @@ fn wallet_pubkey() -> Result<String, String> {
 }
 
 struct BriefInput {
-    details: Option<String>,
-    budget_usd: Option<f64>,
+    build: Option<String>,
+    today: Option<String>,
 }
 
-/// The single prompt: sell the gap, collect optional signal, and take
-/// Accept as consent to submit. Returns `Ok(None)` on Decline/Cancel.
+/// The single prompt: sell the gap, collect two free-form answers, and
+/// take Accept as consent to submit. Both answers are plain text on
+/// purpose — a model structures them afterwards, so the user never fights
+/// a form. Returns `Ok(None)` on Decline/Cancel.
 async fn ask_to_build(
     peer: &Peer<RoleServer>,
     query: &str,
-    weak_candidates: usize,
 ) -> Result<Option<BriefInput>, CapabilityRequestError> {
     let schema = ElicitationSchema::builder()
-        .optional_string_with("details", |s| {
-            s.title("What should it do?").description(
-                "Anything the builders should know — inputs, outputs, must-haves. Leave empty to send your search as the brief.",
+        .optional_string_with("build", |s| {
+            s.title("What do we want to build?").description(
+                "Say it like you'd pitch a friend — \"an API that forecasts Solana priority fees an hour ahead\". Any detail helps: inputs, outputs, budget.",
             )
         })
-        .optional_number_with("budget_usd", |n| {
-            n.range(0.0, 1_000_000.0)
-                .title("Budget ceiling (USD)")
-                .description("Rough signal for quoting — not a commitment, nothing is charged.")
+        .optional_string_with("today", |s| {
+            s.title("What service or app would you use today to achieve that?").description(
+                "Even a clunky workaround — \"I'd eyeball Jito's dashboard\". It shows studios the bar to beat.",
+            )
         })
-        .title("Let's get it built")
+        .title("Build something people want")
         .build()
         .map_err(|e| {
             CapabilityRequestError::Other(format!("failed to build capability-request schema: {e}"))
         })?;
 
     let params = CreateElicitationRequestParam {
-        message: pitch(query, weak_candidates),
+        message: pitch(query),
         requested_schema: schema,
     };
 
@@ -220,22 +277,164 @@ async fn ask_to_build(
 
     let content = outcome.content.unwrap_or_default();
     Ok(Some(BriefInput {
-        details: str_field(&content, "details"),
-        budget_usd: content.get("budget_usd").and_then(|v| v.as_f64()),
+        build: str_field(&content, "build"),
+        today: str_field(&content, "today"),
     }))
 }
 
-fn pitch(query: &str, weak_candidates: usize) -> String {
-    let gap = if weak_candidates == 0 {
-        format!("Nothing in Pay's catalog can do \"{query}\" yet — you've found a gap.")
-    } else {
-        format!(
-            "Nothing in Pay's catalog truly fits \"{query}\" (only {weak_candidates} loose keyword matches, listed in the results) — you've found a gap."
-        )
+fn pitch(query: &str) -> String {
+    let need = truncate_chars(query, PITCH_NEED_MAX_CHARS);
+    let pitch = format!(
+        "No API in Pay does \"{need}\" yet — you just found real demand.\nStudios can build & ship it: a live API, published under you, earning on every call.\nAsking is free; nothing's charged unless you accept a quote."
+    );
+    debug_assert!(pitch.chars().count() <= PITCH_MAX_CHARS);
+    pitch
+}
+
+/// Char-boundary-safe truncation with an ellipsis, counting chars (not
+/// bytes) to match the pitch's char budget.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct StructuredBrief {
+    product: Option<String>,
+    competition: Vec<String>,
+    budget_usd: Option<f64>,
+    monetization: Option<String>,
+}
+
+fn supports_sampling(peer: &Peer<RoleServer>) -> bool {
+    peer.peer_info()
+        .is_some_and(|info| info.capabilities.sampling.is_some())
+}
+
+/// Structure the free-form answers with the client's own model (MCP
+/// sampling), briefed by [`BRIEF_SKILL`]. Best-effort: returns the empty
+/// brief when the client can't sample, times out, or replies with
+/// something that isn't the JSON the skill asked for — the raw answers
+/// still ship in that case.
+async fn structure_brief(
+    peer: &Peer<RoleServer>,
+    query: &str,
+    brief: &BriefInput,
+) -> StructuredBrief {
+    if !supports_sampling(peer) {
+        return StructuredBrief::default();
+    }
+    let prompt = format!(
+        "Catalog search that missed: {query}\n\nWhat do we want to build:\n{}\n\nWhat would they use today:\n{}",
+        brief.build.as_deref().unwrap_or("(no answer)"),
+        brief.today.as_deref().unwrap_or("(no answer)"),
+    );
+    let request = CreateMessageRequestParam {
+        messages: vec![SamplingMessage {
+            role: Role::User,
+            content: Content::text(prompt),
+        }],
+        model_preferences: None,
+        system_prompt: Some(BRIEF_SKILL.to_string()),
+        include_context: None,
+        temperature: None,
+        max_tokens: SAMPLING_MAX_TOKENS,
+        stop_sequences: None,
+        metadata: None,
     };
-    format!(
-        "{gap} That's an opportunity: accept and the studio network is asked to build and deploy it — a real API tailored to your exact need, published under you, that other agents pay to use. You found the demand; you can own the service and monetize it. Both fields are optional. Asking is free: the request goes to studios under your Pay wallet, and nothing is charged unless you later accept a quote."
-    )
+    let Ok(Ok(result)) = tokio::time::timeout(SAMPLING_TIMEOUT, peer.create_message(request)).await
+    else {
+        return StructuredBrief::default();
+    };
+    result
+        .message
+        .content
+        .as_text()
+        .and_then(|t| parse_structured_brief(&t.text))
+        .unwrap_or_default()
+}
+
+/// Tolerates fences or prose around the JSON object the skill asked for.
+fn parse_structured_brief(raw: &str) -> Option<StructuredBrief> {
+    let start = raw.find('{')?;
+    let end = raw.rfind('}')?;
+    serde_json::from_str(raw.get(start..=end)?).ok()
+}
+
+/// Best-effort in-flight status line: MCP progress notifications when the
+/// client sent a `progressToken` with the call, logging notifications
+/// otherwise. Clients may ignore either — nothing here can fail the
+/// request.
+struct Status {
+    peer: Peer<RoleServer>,
+    token: Option<ProgressToken>,
+    step: AtomicU64,
+}
+
+impl Status {
+    fn new(peer: Peer<RoleServer>, token: Option<ProgressToken>) -> Self {
+        Self {
+            peer,
+            token,
+            step: AtomicU64::new(0),
+        }
+    }
+
+    async fn send(&self, message: &str) {
+        // Progress must be monotonically increasing per the MCP spec.
+        let step = self.step.fetch_add(1, Ordering::Relaxed) + 1;
+        match &self.token {
+            Some(token) => {
+                let _ = self
+                    .peer
+                    .notify_progress(ProgressNotificationParam {
+                        progress_token: token.clone(),
+                        progress: step as f64,
+                        total: None,
+                        message: Some(message.to_string()),
+                    })
+                    .await;
+            }
+            None => {
+                let _ = self
+                    .peer
+                    .notify_logging_message(LoggingMessageNotificationParam {
+                        level: LoggingLevel::Info,
+                        logger: Some("request_capability".to_string()),
+                        data: serde_json::Value::String(message.to_string()),
+                    })
+                    .await;
+            }
+        }
+    }
+}
+
+/// Run `fut` while rotating through `messages` on a timer, so the user
+/// sees what's happening during a long stage instead of a frozen spinner.
+async fn with_rotating_status<T>(
+    status: &Status,
+    messages: &[&str],
+    fut: impl Future<Output = T>,
+) -> T {
+    status.send(messages[0]).await;
+    tokio::pin!(fut);
+    let mut interval = tokio::time::interval(STATUS_ROTATION_INTERVAL);
+    interval.tick().await; // the first tick completes immediately
+    let mut next = 1usize;
+    loop {
+        tokio::select! {
+            out = &mut fut => return out,
+            _ = interval.tick() => {
+                status.send(messages[next % messages.len()]).await;
+                next += 1;
+            }
+        }
+    }
 }
 
 fn budget_from_usd(usd: f64) -> Option<BudgetAmount> {
@@ -429,15 +628,39 @@ mod tests {
     }
 
     #[test]
-    fn pitch_mentions_weak_matches_only_when_present() {
-        let clean = pitch("solana priority fee forecasts", 0);
-        assert!(clean.contains("can do"));
-        assert!(!clean.contains("loose keyword"));
-        let noisy = pitch("solana priority fee forecasts", 5);
-        assert!(noisy.contains("5 loose keyword matches"));
-        for message in [&clean, &noisy] {
-            assert!(message.contains("monetize"));
-            assert!(message.contains("nothing is charged"));
+    fn pitch_stays_short_and_multiline() {
+        let short = pitch("solana priority fee forecasts");
+        assert!(short.contains("solana priority fee forecasts"));
+        let long = pitch(&"x".repeat(500));
+        for message in [&short, &long] {
+            assert!(
+                message.chars().count() <= PITCH_MAX_CHARS,
+                "pitch is {} chars",
+                message.chars().count()
+            );
+            assert_eq!(message.matches('\n').count(), 2);
         }
+    }
+
+    #[test]
+    fn truncate_chars_is_char_boundary_safe() {
+        assert_eq!(truncate_chars("héllo", 10), "héllo");
+        assert_eq!(truncate_chars("héllo wörld", 6), "héllo…");
+        assert_eq!(truncate_chars("日本語のテキスト", 4), "日本語…");
+    }
+
+    #[test]
+    fn parse_structured_brief_tolerates_fences_and_prose() {
+        let fenced = "Here you go:\n```json\n{\"product\": \"fee forecast API\", \"competition\": [\"Jito dashboard\"], \"budget_usd\": 50}\n```";
+        let brief = parse_structured_brief(fenced).unwrap();
+        assert_eq!(brief.product.as_deref(), Some("fee forecast API"));
+        assert_eq!(brief.competition, vec!["Jito dashboard"]);
+        assert_eq!(brief.budget_usd, Some(50.0));
+        assert_eq!(brief.monetization, None);
+
+        // Partial objects deserialize with defaults; garbage does not.
+        assert!(parse_structured_brief("{}").is_some());
+        assert!(parse_structured_brief("no json here").is_none());
+        assert!(parse_structured_brief("{not json}").is_none());
     }
 }

--- a/rust/crates/mcp/src/tools/request_capability.rs
+++ b/rust/crates/mcp/src/tools/request_capability.rs
@@ -234,7 +234,7 @@ fn pitch(query: &str, weak_candidates: usize) -> String {
         )
     };
     format!(
-        "{gap} Want it to exist? Accept and the studio network is asked to build and deploy an API tailored to your exact need — one you can monetize once it's live. Both fields are optional. Asking is free: the request goes to studios under your Pay wallet, and nothing is charged unless you later accept a quote."
+        "{gap} That's an opportunity: accept and the studio network is asked to build and deploy it — a real API tailored to your exact need, published under you, that other agents pay to use. You found the demand; you can own the service and monetize it. Both fields are optional. Asking is free: the request goes to studios under your Pay wallet, and nothing is charged unless you later accept a quote."
     )
 }
 

--- a/rust/crates/mcp/src/tools/request_capability_brief.md
+++ b/rust/crates/mcp/src/tools/request_capability_brief.md
@@ -1,34 +1,41 @@
-# Capability-request brief extraction
+# Capability refiner
 
-You turn a user's free-form answers about a missing API capability into the
-structured brief studios quote against. The user typed casually; you extract,
-you never embellish.
+Turn a Pay catalog miss and the buyer's two casual answers into a quote-ready
+API specification. You are the buyer-side research agent: studios must not do
+free discovery work after receiving this RFQ.
 
-Input: the catalog search that missed, plus the user's answers to two
-questions — what they want built, and what service or app they would use
-today to achieve it. Either answer may be missing.
+Work inside this sampling conversation. Use the read-only Pay catalog tools to
+verify the miss and inspect plausible adjacent services. You may use the local
+model's existing knowledge, but label anything not supported by the user's
+answers or a tool result as an assumption. Never invent a source, a live price,
+or a user's budget.
 
-Output: a single JSON object and nothing else — no prose, no code fences.
+Research and decide:
 
-{
-  "product": string or null,
-  "competition": [string, ...],
-  "budget_usd": number or null,
-  "monetization": string or null
-}
+1. What exact API should exist, including the smallest useful input/output.
+2. What current service or workaround sets the bar, and why it falls short.
+3. Freshness: realtime, a defensible cache TTL, or a scheduled cron.
+4. Paid upstream dependencies and their per-call cost only when verified.
+5. Monthly call volume and average request/response sizes. Conservative
+   estimates are allowed, but must also appear in `assumptions`.
+6. Compute class (`proxy`, `cpu`, `gpu`), state, and interface.
+7. One realistic example request/response that doubles as an acceptance test.
 
-Rules:
+Return exactly one JSON object matching the schema in the user message. No
+prose and no code fence. The outer fields mean:
 
-- product: one or two crisp sentences a builder can act on. Keep every
-  concrete detail the user gave — inputs, outputs, formats, frequencies,
-  chains, thresholds — and drop the filler. If they gave no answer, derive
-  it from the search query alone.
-- competition: the services, apps, or workarounds the user says they would
-  use today. One entry per distinct thing, keeping the user's naming. Empty
-  array if none were named.
-- budget_usd: only if the user stated an amount of money they would spend,
-  converted to a plain USD number. Never invent or infer one.
-- monetization: only if the user said how they would charge for or
-  commercially use the service. Otherwise null.
-- Nothing in the output may claim a fact the user or the query did not give
-  you. When unsure, leave the field null or empty.
+- `product`: one or two crisp builder-facing sentences; never empty.
+- `competition`: distinct named services or workarounds, or `[]`.
+- `budget_usd`: a positive number only when the user explicitly gave one;
+  otherwise `null`.
+- `monetization`: only what the user said or a clearly labeled conservative
+  proposal; otherwise `null`.
+- `brief`: the complete quote-sizing and delivery-acceptance specification.
+- `sources`: each source/tool result actually used, with a short finding. A
+  user answer may be labeled as a source with no URL.
+- `assumptions`: every estimate or unresolved uncertainty that could change a
+  quote.
+
+Fail closed in your own reasoning: do not produce a shallow placeholder brief.
+If evidence is unavailable, make the narrowest reasonable assumption and name
+it explicitly instead of presenting it as fact.

--- a/rust/crates/mcp/src/tools/request_capability_brief.md
+++ b/rust/crates/mcp/src/tools/request_capability_brief.md
@@ -1,0 +1,34 @@
+# Capability-request brief extraction
+
+You turn a user's free-form answers about a missing API capability into the
+structured brief studios quote against. The user typed casually; you extract,
+you never embellish.
+
+Input: the catalog search that missed, plus the user's answers to two
+questions — what they want built, and what service or app they would use
+today to achieve it. Either answer may be missing.
+
+Output: a single JSON object and nothing else — no prose, no code fences.
+
+{
+  "product": string or null,
+  "competition": [string, ...],
+  "budget_usd": number or null,
+  "monetization": string or null
+}
+
+Rules:
+
+- product: one or two crisp sentences a builder can act on. Keep every
+  concrete detail the user gave — inputs, outputs, formats, frequencies,
+  chains, thresholds — and drop the filler. If they gave no answer, derive
+  it from the search query alone.
+- competition: the services, apps, or workarounds the user says they would
+  use today. One entry per distinct thing, keeping the user's naming. Empty
+  array if none were named.
+- budget_usd: only if the user stated an amount of money they would spend,
+  converted to a plain USD number. Never invent or infer one.
+- monetization: only if the user said how they would charge for or
+  commercially use the service. Otherwise null.
+- Nothing in the output may claim a fact the user or the query did not give
+  you. When unsure, leave the field null or empty.

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -97,6 +97,7 @@ fn default_max_results() -> usize {
 pub async fn run(
     params: Params,
     peer: rmcp::Peer<rmcp::service::RoleServer>,
+    progress_token: Option<rmcp::model::ProgressToken>,
 ) -> Result<CallToolResult, rmcp::ErrorData> {
     let query = params.query.trim().to_string();
     if query.is_empty() {
@@ -137,7 +138,7 @@ pub async fn run(
     // to `request_capability` instead of prompting the user directly.
     if response.catalog_miss
         && let Some(capability_request) =
-            offer_capability_request(&peer, &query, response.candidates.len()).await
+            offer_capability_request(&peer, progress_token, &query).await
     {
         response.next_step = next_step_for_capability_request(&capability_request);
         response.capability_request = Some(capability_request);
@@ -164,11 +165,11 @@ pub async fn run(
 /// in [`next_step_for_candidates`] instead of erroring the whole search.
 async fn offer_capability_request(
     peer: &rmcp::Peer<rmcp::service::RoleServer>,
+    progress_token: Option<rmcp::model::ProgressToken>,
     query: &str,
-    weak_candidates: usize,
 ) -> Option<serde_json::Value> {
     use super::request_capability::{CapabilityRequestError, CapabilityRequestOutcome};
-    match super::request_capability::run_capability_request(peer, query, weak_candidates).await {
+    match super::request_capability::run_capability_request(peer, progress_token, query).await {
         Ok(CapabilityRequestOutcome::Submitted(value)) => Some(value),
         Ok(CapabilityRequestOutcome::Declined) => Some(serde_json::json!({
             "status": "declined",

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -300,12 +300,12 @@ fn call_plan_fields() -> Vec<String> {
 
 fn next_step_for_candidates(candidates: &[CandidateEntry]) -> String {
     let Some(top) = candidates.first() else {
-        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. This client could not be asked for capability-request consent, so nothing was submitted; call request_capability directly if the user wants a new provider built, otherwise ask before using a non-Pay fallback.".to_string();
+        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. This client could not be asked for capability-request consent, so nothing was submitted; call request_capability to offer getting it built — frame it as the opportunity it is (the user found unmet demand; a studio builds and deploys the API and the user publishes and monetizes it), not as a formality — otherwise ask before using a non-Pay fallback.".to_string();
     };
 
     if !candidates.iter().any(|c| c.strong) {
         return format!(
-            "Every candidate is a weak keyword match; none clearly fits the task. Inspect `{}` with get_catalog_entry if it might still cover it — but if nothing here actually covers the user's need, call request_capability with the task: it asks the user for consent itself, so calling it on a suspected miss is safe.",
+            "Every candidate is a weak keyword match; none clearly fits the task. Inspect `{}` with get_catalog_entry if it might still cover it. If nothing here covers the user's need, they just found a gap in the catalog — an opportunity, not a dead end: call request_capability with the task directly instead of asking permission in chat (the tool prompts the user itself; a chat-level pre-ask is a duplicate consent step). If you mention it at all, pitch what it is — a studio builds and deploys the API and the user publishes and monetizes it — never a bureaucratic 'capability request submission'.",
             top.fqn
         );
     }

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -230,7 +230,7 @@ fn call_plan_fields() -> Vec<String> {
 
 fn next_step_for_candidates(candidates: &[CandidateEntry]) -> String {
     let Some(top) = candidates.first() else {
-        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. If the user wants a new provider built for this, call commission_capability (it asks for consent and details itself — do not call it speculatively); otherwise ask the user before using a non-Pay fallback.".to_string();
+        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. If the user wants a new provider built for this, call request_capability (it asks for consent and details itself — do not call it speculatively); otherwise ask the user before using a non-Pay fallback.".to_string();
     };
 
     if top.endpoint_lookup_error.is_some() || top.endpoints.is_empty() {

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -41,11 +41,8 @@ struct SearchCatalogResponse {
     selection_guidance: Vec<String>,
     call_plan_fields: Vec<String>,
     next_step: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    capability_request: Option<serde_json::Value>,
     /// Internal gate for the capability-request offer (see
-    /// `pay_core::skills::is_catalog_miss`) — not part of the wire response;
-    /// the offer's outcome is reported via `capability_request`/`next_step`.
+    /// `pay_core::skills::is_catalog_miss`) — not part of the wire response.
     #[serde(skip)]
     catalog_miss: bool,
 }
@@ -94,14 +91,20 @@ fn default_max_results() -> usize {
     5
 }
 
-pub async fn run(
-    params: Params,
-    peer: rmcp::Peer<rmcp::service::RoleServer>,
-    progress_token: Option<rmcp::model::ProgressToken>,
-) -> Result<CallToolResult, rmcp::ErrorData> {
+pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
+    run_with_miss(params).await.map(|(result, _miss)| result)
+}
+
+/// Return the visible search result plus the measured catalog-miss gate so
+/// the MCP handler can start the same MRTR call without relying on the model
+/// to notice a prose `next_step` and invoke a second tool.
+pub async fn run_with_miss(params: Params) -> Result<(CallToolResult, bool), rmcp::ErrorData> {
     let query = params.query.trim().to_string();
     if query.is_empty() {
-        return Ok(super::tool_error("`query` must describe the user's task"));
+        return Ok((
+            super::tool_error("`query` must describe the user's task"),
+            false,
+        ));
     }
 
     let cache_bust = params.cache_bust;
@@ -116,12 +119,12 @@ pub async fn run(
     };
     let catalog = match catalog_result {
         Ok(catalog) => catalog,
-        Err(message) => return Ok(super::tool_error(message)),
+        Err(message) => return Ok((super::tool_error(message), false)),
     };
 
     let max_results = params.max_results.clamp(1, 10);
     let category = params.category.clone();
-    let mut response = build_search_catalog_response(
+    let response = build_search_catalog_response(
         catalog,
         query.clone(),
         category,
@@ -130,69 +133,21 @@ pub async fn run(
     )
     .await;
 
-    // Offer gate: a hard miss, or a specific query with only weak keyword
-    // noise (an is_empty() gate never fired — term-overlap noise once scored
-    // an air-quality API at 96 on "solana priority fee forecasts" — while a
-    // bare no-strong gate fires on over half of ordinary fuzzy searches).
-    // For weak-only vague queries the next_step hint below routes the model
-    // to `request_capability` instead of prompting the user directly.
-    if response.catalog_miss
-        && let Some(capability_request) =
-            offer_capability_request(&peer, progress_token, &query).await
-    {
-        response.next_step = next_step_for_capability_request(&capability_request);
-        response.capability_request = Some(capability_request);
-    }
-
     let json = match serde_json::to_string_pretty(&response) {
         Ok(json) => json,
         Err(err) => {
-            return Ok(super::tool_error(format!(
-                "Failed to serialize response: {err}"
-            )));
+            return Ok((
+                super::tool_error(format!("Failed to serialize response: {err}")),
+                false,
+            ));
         }
     };
 
-    Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-        json,
-    )]))
-}
-
-/// On a catalog miss, run the same single-prompt build-request flow
-/// `request_capability` uses — the elicitation itself is the consent gate.
-/// Returns `None` when the elicitation round-trip fails (commonly a client
-/// with no elicitation support) so callers fall back to the plain text hint
-/// in [`next_step_for_candidates`] instead of erroring the whole search.
-async fn offer_capability_request(
-    peer: &rmcp::Peer<rmcp::service::RoleServer>,
-    progress_token: Option<rmcp::model::ProgressToken>,
-    query: &str,
-) -> Option<serde_json::Value> {
-    use super::request_capability::{CapabilityRequestError, CapabilityRequestOutcome};
-    match super::request_capability::run_capability_request(peer, progress_token, query).await {
-        Ok(CapabilityRequestOutcome::Submitted(value)) => Some(value),
-        Ok(CapabilityRequestOutcome::Declined) => Some(serde_json::json!({
-            "status": "declined",
-            "message": "The user declined to request this capability.",
-        })),
-        Err(CapabilityRequestError::Elicitation(_)) => None,
-        Err(CapabilityRequestError::Other(message)) => {
-            Some(serde_json::json!({ "status": "failed", "error": message }))
-        }
-    }
-}
-
-fn next_step_for_capability_request(value: &serde_json::Value) -> String {
-    if let Some(next_step) = value.get("next_step").and_then(|v| v.as_str()) {
-        return next_step.to_string();
-    }
-
-    match value.get("status").and_then(|v| v.as_str()) {
-        Some("declined") => {
-            "The user declined a capability request for this query; ask before using a non-Pay fallback.".to_string()
-        }
-        _ => "The capability request could not be completed; show the user the error before retrying.".to_string(),
-    }
+    let catalog_miss = response.catalog_miss;
+    Ok((
+        CallToolResult::success(vec![rmcp::model::ContentBlock::text(json)]),
+        catalog_miss,
+    ))
 }
 
 async fn build_search_catalog_response(
@@ -265,7 +220,6 @@ async fn build_search_catalog_response(
         selection_guidance: selection_guidance(),
         call_plan_fields: call_plan_fields(),
         next_step,
-        capability_request: None,
         catalog_miss,
     }
 }
@@ -526,29 +480,6 @@ mod tests {
         assert!(response.candidates.iter().any(|c| c.strong));
         assert!(!response.catalog_miss);
         assert!(!response.next_step.contains("request_capability"));
-    }
-
-    #[test]
-    fn next_step_for_capability_request_prefers_inner_next_step() {
-        let value = serde_json::json!({
-            "next_step": "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically.",
-        });
-        assert_eq!(
-            next_step_for_capability_request(&value),
-            "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically."
-        );
-    }
-
-    #[test]
-    fn next_step_for_capability_request_handles_declined_status() {
-        let value = serde_json::json!({ "status": "declined" });
-        assert!(next_step_for_capability_request(&value).contains("declined"));
-    }
-
-    #[test]
-    fn next_step_for_capability_request_handles_failed_status() {
-        let value = serde_json::json!({ "status": "failed", "error": "boom" });
-        assert!(next_step_for_capability_request(&value).contains("could not be completed"));
     }
 
     #[tokio::test]

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -43,6 +43,11 @@ struct SearchCatalogResponse {
     next_step: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     capability_request: Option<serde_json::Value>,
+    /// Internal gate for the capability-request offer (see
+    /// `pay_core::skills::is_catalog_miss`) — not part of the wire response;
+    /// the offer's outcome is reported via `capability_request`/`next_step`.
+    #[serde(skip)]
+    catalog_miss: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -59,6 +64,11 @@ struct CandidateEntry {
     max_price_usd: f64,
     score: u32,
     reasons: Vec<String>,
+    /// Whether this candidate clearly fits the query (see
+    /// `pay_core::skills::RankedServiceSummary::strong`). When no candidate
+    /// is strong, the search counts as a catalog miss for the
+    /// capability-request offer even though weak matches are listed.
+    strong: bool,
     endpoints: Vec<EndpointEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     endpoint_lookup_error: Option<String>,
@@ -119,8 +129,15 @@ pub async fn run(
     )
     .await;
 
-    if response.candidates.is_empty()
-        && let Some(capability_request) = offer_capability_request(&peer, &query).await
+    // Offer gate: a hard miss, or a specific query with only weak keyword
+    // noise (an is_empty() gate never fired — term-overlap noise once scored
+    // an air-quality API at 96 on "solana priority fee forecasts" — while a
+    // bare no-strong gate fires on over half of ordinary fuzzy searches).
+    // For weak-only vague queries the next_step hint below routes the model
+    // to `request_capability` instead of prompting the user directly.
+    if response.catalog_miss
+        && let Some(capability_request) =
+            offer_capability_request(&peer, &query, response.candidates.len()).await
     {
         response.next_step = next_step_for_capability_request(&capability_request);
         response.capability_request = Some(capability_request);
@@ -140,26 +157,27 @@ pub async fn run(
     )]))
 }
 
-/// On a catalog miss, ask the connected MCP client for consent to submit a
-/// capability request, then run the same interview + studio-submission flow
-/// `request_capability` uses. Returns `None` when the client doesn't support
-/// elicitation (or the round-trip otherwise fails) so callers fall back to
-/// the plain text hint in [`next_step_for_candidates`] instead of erroring
-/// the whole search.
+/// On a catalog miss, run the same single-prompt build-request flow
+/// `request_capability` uses — the elicitation itself is the consent gate.
+/// Returns `None` when the elicitation round-trip fails (commonly a client
+/// with no elicitation support) so callers fall back to the plain text hint
+/// in [`next_step_for_candidates`] instead of erroring the whole search.
 async fn offer_capability_request(
     peer: &rmcp::Peer<rmcp::service::RoleServer>,
     query: &str,
+    weak_candidates: usize,
 ) -> Option<serde_json::Value> {
-    match super::request_capability::ask_consent(peer, query).await {
-        Ok(true) => match super::request_capability::run_capability_request(peer, query).await {
-            Ok(value) => Some(value),
-            Err(message) => Some(serde_json::json!({ "status": "failed", "error": message })),
-        },
-        Ok(false) => Some(serde_json::json!({
+    use super::request_capability::{CapabilityRequestError, CapabilityRequestOutcome};
+    match super::request_capability::run_capability_request(peer, query, weak_candidates).await {
+        Ok(CapabilityRequestOutcome::Submitted(value)) => Some(value),
+        Ok(CapabilityRequestOutcome::Declined) => Some(serde_json::json!({
             "status": "declined",
             "message": "The user declined to request this capability.",
         })),
-        Err(_) => None,
+        Err(CapabilityRequestError::Elicitation(_)) => None,
+        Err(CapabilityRequestError::Other(message)) => {
+            Some(serde_json::json!({ "status": "failed", "error": message }))
+        }
     }
 }
 
@@ -207,6 +225,7 @@ async fn build_search_catalog_response(
         category.as_deref(),
         max_results,
     );
+    let catalog_miss = pay_core::skills::is_catalog_miss(&query, &ranked);
 
     let candidates: Vec<CandidateEntry> = ranked
         .into_iter()
@@ -232,6 +251,7 @@ async fn build_search_catalog_response(
                 max_price_usd: candidate.service.max_price_usd,
                 score: candidate.score,
                 reasons: candidate.reasons,
+                strong: candidate.strong,
                 endpoints,
             }
         })
@@ -245,6 +265,7 @@ async fn build_search_catalog_response(
         call_plan_fields: call_plan_fields(),
         next_step,
         capability_request: None,
+        catalog_miss,
     }
 }
 
@@ -281,6 +302,13 @@ fn next_step_for_candidates(candidates: &[CandidateEntry]) -> String {
     let Some(top) = candidates.first() else {
         return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. This client could not be asked for capability-request consent, so nothing was submitted; call request_capability directly if the user wants a new provider built, otherwise ask before using a non-Pay fallback.".to_string();
     };
+
+    if !candidates.iter().any(|c| c.strong) {
+        return format!(
+            "Every candidate is a weak keyword match; none clearly fits the task. Inspect `{}` with get_catalog_entry if it might still cover it — but if nothing here actually covers the user's need, call request_capability with the task: it asks the user for consent itself, so calling it on a suspected miss is safe.",
+            top.fqn
+        );
+    }
 
     if top.endpoint_lookup_error.is_some() || top.endpoints.is_empty() {
         return format!(
@@ -424,7 +452,15 @@ mod tests {
     use super::*;
     use std::collections::BTreeMap;
 
-    const GLOBAL_CURRENT_BENCHMARK: f64 = 83.722;
+    // Repinned after the miss-detection scoring fixes (shared curation-org
+    // prefixes stop earning term-match credit; the provider-size bonus no
+    // longer keeps zero-term-match providers in the list): rank-weighted
+    // 83.722 -> 83.117, top1 unchanged at 77.111 (694/900 rank-1). The
+    // rank-weighted drop is 94 fuzzy prompts whose expected provider used
+    // to appear at rank 2-5 purely via the size bonus (score 6-12, no term
+    // matched) — luck, not routing signal, and the same floor that made a
+    // catalog miss undetectable.
+    const GLOBAL_CURRENT_BENCHMARK: f64 = 83.117;
     const GLOBAL_CURRENT_TOP1_BENCHMARK: f64 = 77.111;
     const BENCHMARK_EPSILON: f64 = 0.001;
 
@@ -469,7 +505,26 @@ mod tests {
                 .iter()
                 .any(|field| field == "estimated total spend")
         );
-        assert!(response.next_step.contains("call plan") || response.next_step.contains("Compare"));
+        // Every candidate for this fuzzy phrasing is a weak keyword match,
+        // so next_step routes the model to the consent-gated
+        // request_capability escape hatch instead of endpoint comparison.
+        assert!(response.next_step.contains("request_capability"));
+    }
+
+    #[tokio::test]
+    async fn search_catalog_next_step_compares_when_fit_is_clear() {
+        let response = build_search_catalog_response(
+            bench_catalog(),
+            "instagram influencer search by location".to_string(),
+            None,
+            5,
+            pay_core::ClientApp::Cli,
+        )
+        .await;
+        assert!(!response.candidates.is_empty());
+        assert!(response.candidates.iter().any(|c| c.strong));
+        assert!(!response.catalog_miss);
+        assert!(!response.next_step.contains("request_capability"));
     }
 
     #[test]

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -41,6 +41,8 @@ struct SearchCatalogResponse {
     selection_guidance: Vec<String>,
     call_plan_fields: Vec<String>,
     next_step: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capability_request: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,7 +84,10 @@ fn default_max_results() -> usize {
     5
 }
 
-pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
+pub async fn run(
+    params: Params,
+    peer: rmcp::Peer<rmcp::service::RoleServer>,
+) -> Result<CallToolResult, rmcp::ErrorData> {
     let query = params.query.trim().to_string();
     if query.is_empty() {
         return Ok(super::tool_error("`query` must describe the user's task"));
@@ -105,14 +110,21 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
 
     let max_results = params.max_results.clamp(1, 10);
     let category = params.category.clone();
-    let response = build_search_catalog_response(
+    let mut response = build_search_catalog_response(
         catalog,
-        query,
+        query.clone(),
         category,
         max_results,
         pay_core::ClientApp::Mcp,
     )
     .await;
+
+    if response.candidates.is_empty()
+        && let Some(capability_request) = offer_capability_request(&peer, &query).await
+    {
+        response.next_step = next_step_for_capability_request(&capability_request);
+        response.capability_request = Some(capability_request);
+    }
 
     let json = match serde_json::to_string_pretty(&response) {
         Ok(json) => json,
@@ -126,6 +138,42 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         json,
     )]))
+}
+
+/// On a catalog miss, ask the connected MCP client for consent to submit a
+/// capability request, then run the same interview + studio-submission flow
+/// `request_capability` uses. Returns `None` when the client doesn't support
+/// elicitation (or the round-trip otherwise fails) so callers fall back to
+/// the plain text hint in [`next_step_for_candidates`] instead of erroring
+/// the whole search.
+async fn offer_capability_request(
+    peer: &rmcp::Peer<rmcp::service::RoleServer>,
+    query: &str,
+) -> Option<serde_json::Value> {
+    match super::request_capability::ask_consent(peer, query).await {
+        Ok(true) => match super::request_capability::run_capability_request(peer, query).await {
+            Ok(value) => Some(value),
+            Err(message) => Some(serde_json::json!({ "status": "failed", "error": message })),
+        },
+        Ok(false) => Some(serde_json::json!({
+            "status": "declined",
+            "message": "The user declined to request this capability.",
+        })),
+        Err(_) => None,
+    }
+}
+
+fn next_step_for_capability_request(value: &serde_json::Value) -> String {
+    if let Some(next_step) = value.get("next_step").and_then(|v| v.as_str()) {
+        return next_step.to_string();
+    }
+
+    match value.get("status").and_then(|v| v.as_str()) {
+        Some("declined") => {
+            "The user declined a capability request for this query; ask before using a non-Pay fallback.".to_string()
+        }
+        _ => "The capability request could not be completed; show the user the error before retrying.".to_string(),
+    }
 }
 
 async fn build_search_catalog_response(
@@ -196,6 +244,7 @@ async fn build_search_catalog_response(
         selection_guidance: selection_guidance(),
         call_plan_fields: call_plan_fields(),
         next_step,
+        capability_request: None,
     }
 }
 
@@ -230,7 +279,7 @@ fn call_plan_fields() -> Vec<String> {
 
 fn next_step_for_candidates(candidates: &[CandidateEntry]) -> String {
     let Some(top) = candidates.first() else {
-        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. If the user wants a new provider built for this, call request_capability (it asks for consent and details itself — do not call it speculatively); otherwise ask the user before using a non-Pay fallback.".to_string();
+        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. This client could not be asked for capability-request consent, so nothing was submitted; call request_capability directly if the user wants a new provider built, otherwise ask before using a non-Pay fallback.".to_string();
     };
 
     if top.endpoint_lookup_error.is_some() || top.endpoints.is_empty() {
@@ -421,6 +470,29 @@ mod tests {
                 .any(|field| field == "estimated total spend")
         );
         assert!(response.next_step.contains("call plan") || response.next_step.contains("Compare"));
+    }
+
+    #[test]
+    fn next_step_for_capability_request_prefers_inner_next_step() {
+        let value = serde_json::json!({
+            "next_step": "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically.",
+        });
+        assert_eq!(
+            next_step_for_capability_request(&value),
+            "A studio returned a quote. Present price, timeline, and terms to the user before accepting; do not fund automatically."
+        );
+    }
+
+    #[test]
+    fn next_step_for_capability_request_handles_declined_status() {
+        let value = serde_json::json!({ "status": "declined" });
+        assert!(next_step_for_capability_request(&value).contains("declined"));
+    }
+
+    #[test]
+    fn next_step_for_capability_request_handles_failed_status() {
+        let value = serde_json::json!({ "status": "failed", "error": "boom" });
+        assert!(next_step_for_capability_request(&value).contains("could not be completed"));
     }
 
     #[tokio::test]

--- a/rust/crates/mcp/src/tools/search_catalog.rs
+++ b/rust/crates/mcp/src/tools/search_catalog.rs
@@ -230,7 +230,7 @@ fn call_plan_fields() -> Vec<String> {
 
 fn next_step_for_candidates(candidates: &[CandidateEntry]) -> String {
     let Some(top) = candidates.first() else {
-        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale; otherwise ask the user before using a non-Pay fallback.".to_string();
+        return "No matching provider was found. Retry search_catalog once with refresh=true if the catalog may be stale. If the user wants a new provider built for this, call commission_capability (it asks for consent and details itself — do not call it speculatively); otherwise ask the user before using a non-Pay fallback.".to_string();
     };
 
     if top.endpoint_lookup_error.is_some() || top.endpoints.is_empty() {

--- a/rust/crates/mcp/src/tools/topup.rs
+++ b/rust/crates/mcp/src/tools/topup.rs
@@ -162,8 +162,8 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
     let image = general_purpose::STANDARD.encode(&png);
 
     Ok(CallToolResult::success(vec![
-        rmcp::model::Content::text(json),
-        rmcp::model::Content::image(image, "image/png"),
+        rmcp::model::ContentBlock::text(json),
+        rmcp::model::ContentBlock::image(image, "image/png"),
     ]))
 }
 
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn standard_image_content_shape_stays_host_compatible() {
-        let content = rmcp::model::Content::image("abc123", "image/png");
+        let content = rmcp::model::ContentBlock::image("abc123", "image/png");
         let value = serde_json::to_value(&content).expect("serialize content");
 
         assert_eq!(value["type"], "image");

--- a/rust/crates/mcp/tests/elicitation_e2e.rs
+++ b/rust/crates/mcp/tests/elicitation_e2e.rs
@@ -10,16 +10,14 @@
 //! round-trip — without needing a real Pay account, real signing, or any
 //! out-of-process server.
 
-use std::sync::Arc;
-use std::time::Duration;
-
 use pay_keystore::{AuthGate, AuthIntent};
 use pay_mcp::ElicitationAuth;
 use rmcp::{
-    ClientHandler, ErrorData as McpError, ServerHandler, ServiceExt,
+    ClientHandler, ErrorData as McpError, ServerHandler,
     model::*,
-    service::{RequestContext, RoleClient},
+    service::{RequestContext, RoleClient, RoleServer, serve_directly},
 };
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Minimal server with no tools — we only need it to be alive so we can
@@ -33,7 +31,7 @@ impl ServerHandler for BareServer {}
 #[derive(Clone)]
 struct ConfigurableClient {
     action: ElicitationAction,
-    last_request: Arc<Mutex<Option<CreateElicitationRequestParam>>>,
+    last_request: Arc<Mutex<Option<ElicitRequestParams>>>,
 }
 
 impl ConfigurableClient {
@@ -48,47 +46,43 @@ impl ConfigurableClient {
 impl ClientHandler for ConfigurableClient {
     async fn create_elicitation(
         &self,
-        request: CreateElicitationRequestParam,
+        request: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
-    ) -> Result<CreateElicitationResult, McpError> {
+    ) -> Result<ElicitResult, McpError> {
         *self.last_request.lock().await = Some(request);
         let content = if matches!(self.action, ElicitationAction::Accept) {
             Some(serde_json::json!({ "approved": true }))
         } else {
             None
         };
-        Ok(CreateElicitationResult {
-            action: self.action.clone(),
-            content,
+        let result = ElicitResult::new(self.action.clone());
+        Ok(match content {
+            Some(content) => result.with_content(content),
+            None => result,
         })
     }
 }
 
 async fn run_with_action(
     action: ElicitationAction,
-) -> (
-    Result<(), pay_keystore::Error>,
-    Option<CreateElicitationRequestParam>,
-) {
+) -> (Result<(), pay_keystore::Error>, Option<ElicitRequestParams>) {
     let (server_transport, client_transport) = tokio::io::duplex(8192);
 
-    let server = BareServer
-        .serve(server_transport)
-        .await
-        .expect("server should serve");
     let client_handler = ConfigurableClient::new(action);
-    let client = client_handler
-        .clone()
-        .serve(client_transport)
-        .await
-        .expect("client should serve");
-
-    // Let the initialize handshake finish before we send elicitation.
-    // 1s is generous enough for CI runners under load — rmcp 0.9's
-    // server-side `on_initialized` hook is unreliable under this duplex
-    // setup, so we fall back to a fixed delay. The outer 30s timeout in
-    // each test wraps this so a stuck handshake fails loudly.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    let client_info = ClientInfo::new(
+        ClientCapabilities::builder().enable_elicitation().build(),
+        Implementation::new("pay-mcp-test-client", "0.0.0"),
+    )
+    .with_protocol_version(ProtocolVersion::V_2025_06_18);
+    let server_info = ServerInfo::new(ServerCapabilities::default())
+        .with_protocol_version(ProtocolVersion::V_2025_06_18);
+    let server =
+        serve_directly::<RoleServer, _, _, _, _>(BareServer, server_transport, Some(client_info));
+    let client = serve_directly::<RoleClient, _, _, _, _>(
+        client_handler.clone(),
+        client_transport,
+        Some(server_info.into()),
+    );
 
     let server_peer = server.peer().clone();
     let auth = ElicitationAuth::new(server_peer);
@@ -111,20 +105,6 @@ async fn run_with_action(
     (result, received)
 }
 
-// These three tests reliably hang under rmcp 0.9's `tokio::io::duplex`
-// transport — `peer.create_elicitation` never receives its response —
-// and that hang reproduces both locally and on CI runners regardless of
-// any code in this PR (verified by stashing every PR-local change and
-// re-running). The test file was added in `569c317 feat: enable
-// elicitation` but its CI never executed (no Rust workflow ran on that
-// commit), so the hang has been latent since day one.
-//
-// Ignored until we either (a) upgrade rmcp to a version where the duplex
-// roundtrip works, (b) replace the in-memory duplex with a real socket
-// pair, or (c) drive the I/O loops manually. The protocol-level builder
-// tests (in `src/auth.rs`) still exercise schema + message construction.
-
-#[ignore = "rmcp 0.9 duplex transport hangs on elicitation roundtrip — see file comment"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn auth_succeeds_when_client_accepts() {
     let (result, received) = run_with_action(ElicitationAction::Accept).await;
@@ -135,19 +115,19 @@ async fn auth_succeeds_when_client_accepts() {
 
     let req = received.expect("client should have received an elicitation");
     // The message should carry the amount and operator from the intent.
+    let ElicitRequestParams::FormElicitationParams { message, .. } = req else {
+        panic!("expected form elicitation");
+    };
     assert!(
-        req.message.contains("$0.50"),
-        "message should mention amount: {:?}",
-        req.message
+        message.contains("$0.50"),
+        "message should mention amount: {message:?}"
     );
     assert!(
-        req.message.contains("test API call"),
-        "message should mention reason: {:?}",
-        req.message
+        message.contains("test API call"),
+        "message should mention reason: {message:?}"
     );
 }
 
-#[ignore = "rmcp 0.9 duplex transport hangs on elicitation roundtrip — see file comment"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn auth_fails_closed_when_client_declines() {
     let (result, received) = run_with_action(ElicitationAction::Decline).await;
@@ -159,7 +139,6 @@ async fn auth_fails_closed_when_client_declines() {
     assert!(received.is_some(), "client should have seen the request");
 }
 
-#[ignore = "rmcp 0.9 duplex transport hangs on elicitation roundtrip — see file comment"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn auth_fails_closed_when_client_cancels() {
     let (result, _received) = run_with_action(ElicitationAction::Cancel).await;


### PR DESCRIPTION
## Summary

- Keep catalog-miss intake inside one resumable MCP 2026-07-28 MRTR call: consent, local client sampling, bounded read-only Pay catalog research, strict brief validation, then studio submission.
- Start the same flow directly from `search_catalog` on a measured miss; fail closed when the client lacks MRTR, form elicitation, or sampling-with-tools support.
- Send studios a quote-ready `CapabilityBrief`; integrity- and TTL-bind request state, replay-protect actual submission attempts, and keep local registry setup failures retryable.
- Reuse operator-signed MPP payment sessions across MCP `curl` calls. Session preparation and serialized credential state live in `pay-core` and are shared with the payer proxy; x402 alternatives remain available for unsupported session shapes.
- Upgrade to `rmcp` 3.1 while preserving request-associated payment approval flows.

## Test plan

- [x] `cargo test --workspace -- --test-threads=1 --format=terse` — 1,796 passed, 0 failed, 1 ignored
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

## Compatibility

Capability refinement requires MCP 2026-07-28 MRTR with form elicitation and sampling tools. Older clients receive an actionable unsupported-flow result and no RFQ is submitted. MCP session state is in-memory and renegotiates after process restart; explicit x402 selection remains supported.
